### PR TITLE
Cut verification/signing/proofs etc. time by half for 64bit machines

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ unstable = []
 default = []
 bullet-proof-sizing = []
 dev = ["clippy"]
+lowmemory = []
 
 [dependencies]
 arrayvec = "0.3"

--- a/build.rs
+++ b/build.rs
@@ -21,21 +21,39 @@
 #![deny(unused_mut)]
 #![warn(missing_docs)]
 
+use std::env;
 fn main() {
+    if cfg!(feature = "external-symbols") {
+        println!("cargo:rustc-link-lib=static=secp256k1-zkp");
+        return;
+    }
+
+    // Check whether we can use 64-bit compilation
+    let use_64bit_compilation = if env::var("CARGO_CFG_TARGET_POINTER_WIDTH").unwrap() == "64" {
+        let check = cc::Build::new().file("depend/check_uint128_t.c")
+                                    .cargo_metadata(false)
+                                    .try_compile("check_uint128_t")
+                                    .is_ok();
+        if !check {
+            println!("cargo:warning=Compiling in 32-bit mode on a 64-bit architecture due to lack of uint128_t support.");
+        }
+        check
+    } else {
+        false
+    };
+
+    // Actual build
     let mut base_config = cc::Build::new();
     base_config.include("depend/secp256k1-zkp/")
                .include("depend/secp256k1-zkp/include")
                .include("depend/secp256k1-zkp/src")
-               .flag("-g")
+               .flag_if_supported("-Wno-unused-function") // some ecmult stuff is defined but not used upstream
+               .define("SECP256K1_BUILD", Some("1"))
                // TODO these three should be changed to use libgmp, at least until secp PR 290 is merged
                .define("USE_NUM_NONE", Some("1"))
                .define("USE_FIELD_INV_BUILTIN", Some("1"))
                .define("USE_SCALAR_INV_BUILTIN", Some("1"))
-               // TODO these should use 64-bit variants on 64-bit systems
-               .define("USE_FIELD_10X26", Some("1"))
-               .define("USE_SCALAR_8X32", Some("1"))
                .define("USE_ENDOMORPHISM", Some("1"))
-               // These all are OK.
                .define("ENABLE_MODULE_ECDH", Some("1"))
                .define("ENABLE_MODULE_GENERATOR", Some("1"))
                .define("ENABLE_MODULE_RECOVERY", Some("1"))
@@ -43,6 +61,27 @@ fn main() {
                .define("ENABLE_MODULE_BULLETPROOF", Some("1"))
                .define("ENABLE_MODULE_AGGSIG", Some("1"))
                .define("ENABLE_MODULE_SCHNORRSIG", Some("1"));
+
+    if cfg!(feature = "lowmemory") {
+        base_config.define("ECMULT_WINDOW_SIZE", Some("4")); // A low-enough value to consume neglible memory
+    } else {
+        base_config.define("ECMULT_WINDOW_SIZE", Some("15")); // This is the default in the configure file (`auto`)
+    }
+
+    if let Ok(target_endian) = env::var("CARGO_CFG_TARGET_ENDIAN") {
+        if target_endian == "big" {
+            base_config.define("WORDS_BIGENDIAN", Some("1"));
+        }
+    }
+
+    if use_64bit_compilation {
+        base_config.define("USE_FIELD_5X52", Some("1"))
+                   .define("USE_SCALAR_4X64", Some("1"))
+                   .define("HAVE___INT128", Some("1"));
+    } else {
+        base_config.define("USE_FIELD_10X26", Some("1"))
+                   .define("USE_SCALAR_8X32", Some("1"));
+    }
 
     // secp256k1-zkp
     base_config.file("depend/secp256k1-zkp/contrib/lax_der_parsing.c")

--- a/depend/check_uint128_t.c
+++ b/depend/check_uint128_t.c
@@ -1,0 +1,16 @@
+
+#include <stdint.h>
+
+int main(void) {
+    __uint128_t var_128;
+    uint64_t var_64;
+
+    /* Try to shut up "unused variable" warnings */
+    var_64 = 100;
+    var_128 = 100;
+    if (var_64 == var_128) {
+        var_64 = 20;
+    }
+    return 0;
+}
+

--- a/src/aggsig.rs
+++ b/src/aggsig.rs
@@ -392,6 +392,7 @@ impl Drop for AggSigContext {
 
 #[cfg(test)]
 mod tests {
+	extern crate chrono;
 	use super::{
 		add_signatures_single, export_secnonce_single, sign_single, verify_single, verify_batch,
 		AggSigContext, Secp256k1,
@@ -401,6 +402,7 @@ mod tests {
 	use rand::{thread_rng, Rng};
 	use crate::ContextFlag;
 	use crate::{AggSigPartialSignature, Message, Signature};
+	use crate::aggsig::tests::chrono::Utc;
 
 	#[test]
 	fn test_aggsig_multisig() {
@@ -508,6 +510,7 @@ mod tests {
 
 	#[test]
 	fn test_aggsig_batch() {
+		let nano_to_millis = 1.0 / 1_000_000.0;
 		let secp = Secp256k1::with_caps(ContextFlag::Full);
 
 		let mut sigs: Vec<Signature> = vec![];
@@ -531,7 +534,11 @@ mod tests {
 		}
 
 		println!("Verifying aggsig batch of 100");
+		let start = Utc::now().timestamp_nanos();
 		let result = verify_batch(&secp, &sigs, &msgs, &pub_keys);
+		let fin = Utc::now().timestamp_nanos();
+		let dur_ms = (fin - start) as f64 * nano_to_millis;
+		println!("{} signature batch validated in {}ms", 100, dur_ms);
 		assert!(result == true);
 	}
 

--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -120,10 +120,9 @@ mod benches {
 
     #[bench]
     pub fn bench_ecdh(bh: &mut Bencher) {
-        let s = Secp256k1::with_caps(::ContextFlag::SignOnly);
+        let s = Secp256k1::new();
         let (sk, pk) = s.generate_keypair(&mut thread_rng()).unwrap();
 
-        let s = Secp256k1::new();
         bh.iter( || {
             let res = SharedSecret::new(&s, &pk, &sk);
             black_box(res);

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -2102,3 +2102,31 @@ mod tests {
 		assert_eq!(errs, 0);
 	}
 }
+
+
+
+
+#[cfg(all(test, feature = "unstable"))]
+mod benches {
+    use rand::thread_rng;
+    use test::{Bencher, black_box};
+	use super::{ContextFlag, SecretKey, Secp256k1};
+
+    #[bench]
+    pub fn bench_bullet_proof_verification(bh: &mut Bencher) {
+		// Test Bulletproofs without message
+		let secp = Secp256k1::with_caps(ContextFlag::Commit);
+		let blinding = SecretKey::new(&secp, &mut thread_rng());
+		let value = 12345678;
+		let commit = secp.commit(value, blinding.clone()).unwrap();
+		let bullet_proof = secp.bullet_proof(value, blinding.clone(), blinding.clone(), blinding.clone(), None, None);
+        bh.iter( || {
+			let proof_range = secp.verify_bullet_proof(commit, bullet_proof, None).unwrap();
+			assert_eq!(proof_range.min, 0);
+        });
+    }
+}
+
+
+
+


### PR DESCRIPTION
Taking the nice performance optimization for 64bit target from https://github.com/mimblewimble/rust-secp256k1-zkp/pull/71.

A few tests result on my desktop:

1. Schnorr Signature Batch Verification:

Before this optimization:
```
$ cargo test --release -- test_aggsig_batch --nocapture

running 1 test
Verifying aggsig batch of 100
100 signature batch validated in 7.218ms
test aggsig::tests::test_aggsig_batch ... ok
```

After this optimization:
```
$ cargo test --release -- test_aggsig_batch --nocapture

running 1 test
Verifying aggsig batch of 100
100 signature batch validated in 4.019ms
test aggsig::tests::test_aggsig_batch ... ok
```

2. Bullet Proof Batch Verification:
```
$ cargo test --release -- bench_bullet_proof_single_vs_multi --nocapture

running 1 test
--------
Comparing 1 Proofs
1 proofs single validated in 4.95ms
1 proofs batch validated in 4.9879999999999995ms
--------
Comparing 2 Proofs
2 proofs single validated in 10.259ms
2 proofs batch validated in 5.763999999999999ms
--------
Comparing 5 Proofs
5 proofs single validated in 24.759999999999998ms
5 proofs batch validated in 7.856ms
--------
Comparing 10 Proofs
10 proofs single validated in 48.291ms
10 proofs batch validated in 11.266ms
--------
Comparing 100 Proofs
100 proofs single validated in 482.11699999999996ms
100 proofs batch validated in 70.78099999999999ms
--------
Comparing 200 Proofs
200 proofs single validated in 972.313ms
200 proofs batch validated in 137.71ms
test pedersen::tests::bench_bullet_proof_single_vs_multi ... ok
```

After this optimization:
```
$ cargo test --release -- bench_bullet_proof_single_vs_multi --nocapture

running 1 test
--------
Comparing 1 Proofs
1 proofs single validated in 2.993ms
1 proofs batch validated in 2.8089999999999997ms
--------
Comparing 2 Proofs
2 proofs single validated in 5.795999999999999ms
2 proofs batch validated in 3.311ms
--------
Comparing 5 Proofs
5 proofs single validated in 14.263ms
5 proofs batch validated in 4.516ms
--------
Comparing 10 Proofs
10 proofs single validated in 28.397ms
10 proofs batch validated in 6.451ms
--------
Comparing 100 Proofs
100 proofs single validated in 283.887ms
100 proofs batch validated in 39.845ms
--------
Comparing 200 Proofs
200 proofs single validated in 568.4889999999999ms
200 proofs batch validated in 75.88ms
test pedersen::tests::bench_bullet_proof_single_vs_multi ... ok
```