### PR TITLE
Simple secp256k1 context object w/o precomputation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "depend/secp256k1-zkp"]
 	path = depend/secp256k1-zkp
-	url = https://github.com/mimblewimble/secp256k1-zkp
+	url = https://github.com/mwcproject/secp256k1-zkp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "grin_secp256k1zkp"
-version = "0.7.9"
+version = "0.7.10"
 authors = [ "Grin Developers <mimblewimble@lists.launchpad.net>",
             "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>" ]

--- a/src/aggsig.rs
+++ b/src/aggsig.rs
@@ -34,7 +34,7 @@ pub const ZERO_256: [u8; 32] = [
 /// msg: the message to sign
 /// seckey: the secret key
 pub fn export_secnonce_single(secp: &Secp256k1) -> Result<SecretKey, Error> {
-	let mut return_key = SecretKey::new(&secp, &mut thread_rng());
+	let mut return_key = SecretKey::new(&mut thread_rng());
 	let mut seed = [0u8; 32];
 	thread_rng().fill(&mut seed);
 	let retval = unsafe {

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -150,6 +150,8 @@ extern "C" {
 
     pub static secp256k1_nonce_function_default: NonceFn;
 
+    pub static secp256k1_context_no_precomp: *const Context;
+
     // Contexts
     pub fn secp256k1_context_create(flags: c_uint) -> *mut Context;
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -68,10 +68,10 @@ fn random_32_bytes<R: Rng>(rng: &mut R) -> [u8; 32] {
 impl SecretKey {
     /// Creates a new random secret key
     #[inline]
-    pub fn new<R: Rng>(secp: &Secp256k1, rng: &mut R) -> SecretKey {
+    pub fn new<R: Rng>(rng: &mut R) -> SecretKey {
         let mut data = random_32_bytes(rng);
         unsafe {
-            while ffi::secp256k1_ec_seckey_verify(secp.ctx, data.as_ptr()) == 0 {
+            while ffi::secp256k1_ec_seckey_verify(ffi::secp256k1_context_no_precomp, data.as_ptr()) == 0 {
                 data = random_32_bytes(rng);
             }
         }
@@ -80,13 +80,13 @@ impl SecretKey {
 
     /// Converts a `SECRET_KEY_SIZE`-byte slice to a secret key
     #[inline]
-    pub fn from_slice(secp: &Secp256k1, data: &[u8])
+    pub fn from_slice(data: &[u8])
                         -> Result<SecretKey, Error> {
         match data.len() {
             constants::SECRET_KEY_SIZE => {
                 let mut ret = [0; constants::SECRET_KEY_SIZE];
                 unsafe {
-                    if ffi::secp256k1_ec_seckey_verify(secp.ctx, data.as_ptr()) == 0 {
+                    if ffi::secp256k1_ec_seckey_verify(ffi::secp256k1_context_no_precomp, data.as_ptr()) == 0 {
                         return Err(InvalidSecretKey);
                     }
                 }
@@ -99,10 +99,10 @@ impl SecretKey {
 
     #[inline]
     /// Adds one secret key to another, modulo the curve order
-    pub fn add_assign(&mut self, secp: &Secp256k1, other: &SecretKey)
+    pub fn add_assign(&mut self, other: &SecretKey)
                      -> Result<(), Error> {
         unsafe {
-            if ffi::secp256k1_ec_privkey_tweak_add(secp.ctx, self.as_mut_ptr(), other.as_ptr()) != 1 {
+            if ffi::secp256k1_ec_privkey_tweak_add(ffi::secp256k1_context_no_precomp, self.as_mut_ptr(), other.as_ptr()) != 1 {
                 Err(InvalidSecretKey)
             } else {
                 Ok(())
@@ -112,10 +112,10 @@ impl SecretKey {
 
     #[inline]
     /// Multiplies one secret key by another, modulo the curve order
-    pub fn mul_assign(&mut self, secp: &Secp256k1, other: &SecretKey)
+    pub fn mul_assign(&mut self, other: &SecretKey)
                      -> Result<(), Error> {
         unsafe {
-            if ffi::secp256k1_ec_privkey_tweak_mul(secp.ctx, self.as_mut_ptr(), other.as_ptr()) != 1 {
+            if ffi::secp256k1_ec_privkey_tweak_mul(ffi::secp256k1_context_no_precomp, self.as_mut_ptr(), other.as_ptr()) != 1 {
                 Err(InvalidSecretKey)
             } else {
                 Ok(())
@@ -125,10 +125,10 @@ impl SecretKey {
 
     #[inline]
     /// Inverses the secret key
-    pub fn inv_assign(&mut self, secp: &Secp256k1)
+    pub fn inv_assign(&mut self)
                      -> Result<(), Error> {
         unsafe {
-            if ffi::secp256k1_ec_privkey_tweak_inv(secp.ctx, self.as_mut_ptr()) != 1 {
+            if ffi::secp256k1_ec_privkey_tweak_inv(ffi::secp256k1_context_no_precomp, self.as_mut_ptr()) != 1 {
                 Err(InvalidSecretKey)
             } else {
                 Ok(())
@@ -138,10 +138,10 @@ impl SecretKey {
 
     #[inline]
     /// Negates the secret key
-    pub fn neg_assign(&mut self, secp: &Secp256k1)
+    pub fn neg_assign(&mut self)
                      -> Result<(), Error> {
         unsafe {
-            if ffi::secp256k1_ec_privkey_tweak_neg(secp.ctx, self.as_mut_ptr()) != 1 {
+            if ffi::secp256k1_ec_privkey_tweak_neg(ffi::secp256k1_context_no_precomp, self.as_mut_ptr()) != 1 {
                 Err(InvalidSecretKey)
             } else {
                 Ok(())
@@ -158,17 +158,14 @@ impl PublicKey {
     }
 
     /// Creates a new public key as the sum of the provided keys
-    pub fn from_combination(secp: &Secp256k1, in_keys: Vec<&PublicKey>)
+    pub fn from_combination(in_keys: Vec<&PublicKey>)
                          -> Result<PublicKey, Error> {
         let mut retkey = PublicKey::new();
-        if secp.caps == ContextFlag::SignOnly || secp.caps == ContextFlag::None {
-            return Err(IncapableContext);
-        }
         let in_vec:Vec<*const ffi::PublicKey> = in_keys.iter()
         .map(|pk| pk.as_ptr())
         .collect();
         unsafe {
-            if ffi::secp256k1_ec_pubkey_combine(secp.ctx, &mut retkey.0 as *mut _,
+            if ffi::secp256k1_ec_pubkey_combine(ffi::secp256k1_context_no_precomp, &mut retkey.0 as *mut _,
                                                   in_vec.as_ptr(), in_vec.len() as i32) == 1 {
                 Ok(retkey)
             } else {
@@ -221,11 +218,11 @@ impl PublicKey {
 
     /// Creates a public key directly from a slice
     #[inline]
-    pub fn from_slice(secp: &Secp256k1, data: &[u8])
+    pub fn from_slice(data: &[u8])
                       -> Result<PublicKey, Error> {
         let mut pk = unsafe { ffi::PublicKey::blank() };
         unsafe {
-            if ffi::secp256k1_ec_pubkey_parse(secp.ctx, &mut pk, data.as_ptr(),
+            if ffi::secp256k1_ec_pubkey_parse(ffi::secp256k1_context_no_precomp, &mut pk, data.as_ptr(),
                                               data.len() as ::libc::size_t) == 1 {
                 Ok(PublicKey(pk))
             } else {
@@ -238,13 +235,13 @@ impl PublicKey {
     /// Serialize the key as a byte-encoded pair of values. In compressed form
     /// the y-coordinate is represented by only a single bit, as x determines
     /// it up to one bit.
-    pub fn serialize_vec(&self, secp: &Secp256k1, compressed: bool) -> ArrayVec<[u8; constants::PUBLIC_KEY_SIZE]> {
+    pub fn serialize_vec(&self, compressed: bool) -> ArrayVec<[u8; constants::PUBLIC_KEY_SIZE]> {
         let mut ret = ArrayVec::new();
 
         unsafe {
             let mut ret_len = constants::PUBLIC_KEY_SIZE as ::libc::size_t;
             let compressed = if compressed { ffi::SECP256K1_SER_COMPRESSED } else { ffi::SECP256K1_SER_UNCOMPRESSED };
-            let err = ffi::secp256k1_ec_pubkey_serialize(secp.ctx, ret.as_ptr(),
+            let err = ffi::secp256k1_ec_pubkey_serialize(ffi::secp256k1_context_no_precomp, ret.as_ptr(),
                                                          &mut ret_len, self.as_ptr(),
                                                          compressed);
             debug_assert_eq!(err, 1);
@@ -271,7 +268,7 @@ impl PublicKey {
     }
 
     #[inline]
-    /// Muliplies the pk `self` in place by the scalar `other`
+    /// Multiplies the pk `self` in place by the scalar `other`
     pub fn mul_assign(&mut self, secp: &Secp256k1, other: &SecretKey)
                          -> Result<(), Error> {
         if secp.caps == ContextFlag::SignOnly || secp.caps == ContextFlag::None {
@@ -291,7 +288,6 @@ impl PublicKey {
 impl Decodable for PublicKey {
     fn decode<D: Decoder>(d: &mut D) -> Result<PublicKey, D::Error> {
         d.read_seq(|d, len| {
-            let s = Secp256k1::with_caps(crate::ContextFlag::None);
             if len == constants::UNCOMPRESSED_PUBLIC_KEY_SIZE {
                 unsafe {
                     use std::mem;
@@ -299,7 +295,7 @@ impl Decodable for PublicKey {
                     for i in 0..len {
                         ret[i] = d.read_seq_elt(i, |d| Decodable::decode(d))?;
                     }
-                    PublicKey::from_slice(&s, &ret).map_err(|_| d.error("invalid public key"))
+                    PublicKey::from_slice(&ret).map_err(|_| d.error("invalid public key"))
                 }
             } else if len == constants::COMPRESSED_PUBLIC_KEY_SIZE {
                 unsafe {
@@ -308,7 +304,7 @@ impl Decodable for PublicKey {
                     for i in 0..len {
                         ret[i] = d.read_seq_elt(i, |d| Decodable::decode(d))?;
                     }
-                    PublicKey::from_slice(&s, &ret).map_err(|_| d.error("invalid public key"))
+                    PublicKey::from_slice(&ret).map_err(|_| d.error("invalid public key"))
                 }
             } else {
                 Err(d.error("Invalid length"))
@@ -328,8 +324,7 @@ impl From<ffi::PublicKey> for PublicKey {
 
 impl Encodable for PublicKey {
     fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
-        let secp = Secp256k1::with_caps(crate::ContextFlag::None);
-        self.serialize_vec(&secp, true).encode(s)
+        self.serialize_vec(true).encode(s)
     }
 }
 
@@ -350,7 +345,6 @@ impl<'de> Deserialize<'de> for PublicKey {
             {
                 debug_assert!(constants::UNCOMPRESSED_PUBLIC_KEY_SIZE >= constants::COMPRESSED_PUBLIC_KEY_SIZE);
 
-                let s = Secp256k1::with_caps(crate::ContextFlag::None);
                 unsafe {
                     use std::mem;
                     let mut ret: [u8; constants::UNCOMPRESSED_PUBLIC_KEY_SIZE] = mem::MaybeUninit::uninit().assume_init();
@@ -371,7 +365,7 @@ impl<'de> Deserialize<'de> for PublicKey {
 
                     match read_len {
                         constants::UNCOMPRESSED_PUBLIC_KEY_SIZE | constants::COMPRESSED_PUBLIC_KEY_SIZE
-                            => PublicKey::from_slice(&s, &ret[..read_len]).map_err(
+                            => PublicKey::from_slice(&ret[..read_len]).map_err(
                                 |e| match e {
                                         InvalidPublicKey => de::Error::invalid_value(de::Unexpected::Seq, &self),
                                         _ => de::Error::custom(&e.to_string()),
@@ -397,8 +391,7 @@ impl Serialize for PublicKey {
     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
         where S: Serializer
     {
-        let secp = Secp256k1::with_caps(crate::ContextFlag::None);
-        (&self.serialize_vec(&secp, true)[..]).serialize(s)
+        (&self.serialize_vec(true)[..]).serialize(s)
     }
 }
 
@@ -420,13 +413,11 @@ mod test {
     // To make this test fail, just remove `Zeroize` derive from `SecretKey` definition.
     #[test]
     fn skey_clear_on_drop() {
-        let s = Secp256k1::new();
-
         // Create buffer for blinding factor filled with non-zero bytes.
         let sk_bytes = ONE_KEY;
         let ptr = {
             // Fill blinding factor with some "sensitive" data.
-            let sk = SecretKey::from_slice(&s, &sk_bytes[..]).unwrap();
+            let sk = SecretKey::from_slice(&sk_bytes[..]).unwrap();
             sk.0.as_ptr()
 
             // -- after this line SecretKey should be zeroed.
@@ -448,24 +439,22 @@ mod test {
 
     #[test]
     fn skey_from_slice() {
-        let s = Secp256k1::new();
-        let sk = SecretKey::from_slice(&s, &[1; 31]);
+        let sk = SecretKey::from_slice(&[1; 31]);
         assert_eq!(sk, Err(InvalidSecretKey));
 
-        let sk = SecretKey::from_slice(&s, &[1; 32]);
+        let sk = SecretKey::from_slice(&[1; 32]);
         assert!(sk.is_ok());
     }
 
     #[test]
     fn pubkey_from_slice() {
-        let s = Secp256k1::new();
-        assert_eq!(PublicKey::from_slice(&s, &[]), Err(InvalidPublicKey));
-        assert_eq!(PublicKey::from_slice(&s, &[1, 2, 3]), Err(InvalidPublicKey));
+        assert_eq!(PublicKey::from_slice(&[]), Err(InvalidPublicKey));
+        assert_eq!(PublicKey::from_slice(&[1, 2, 3]), Err(InvalidPublicKey));
 
-        let uncompressed = PublicKey::from_slice(&s, &[4, 54, 57, 149, 239, 162, 148, 175, 246, 254, 239, 75, 154, 152, 10, 82, 234, 224, 85, 220, 40, 100, 57, 121, 30, 162, 94, 156, 135, 67, 74, 49, 179, 57, 236, 53, 162, 124, 149, 144, 168, 77, 74, 30, 72, 211, 229, 110, 111, 55, 96, 193, 86, 227, 183, 152, 195, 155, 51, 247, 123, 113, 60, 228, 188]);
+        let uncompressed = PublicKey::from_slice(&[4, 54, 57, 149, 239, 162, 148, 175, 246, 254, 239, 75, 154, 152, 10, 82, 234, 224, 85, 220, 40, 100, 57, 121, 30, 162, 94, 156, 135, 67, 74, 49, 179, 57, 236, 53, 162, 124, 149, 144, 168, 77, 74, 30, 72, 211, 229, 110, 111, 55, 96, 193, 86, 227, 183, 152, 195, 155, 51, 247, 123, 113, 60, 228, 188]);
         assert!(uncompressed.is_ok());
 
-        let compressed = PublicKey::from_slice(&s, &[3, 23, 183, 225, 206, 31, 159, 148, 195, 42, 67, 115, 146, 41, 248, 140, 11, 3, 51, 41, 111, 180, 110, 143, 114, 134, 88, 73, 198, 174, 52, 184, 78]);
+        let compressed = PublicKey::from_slice(&[3, 23, 183, 225, 206, 31, 159, 148, 195, 42, 67, 115, 146, 41, 248, 140, 11, 3, 51, 41, 111, 180, 110, 143, 114, 134, 88, 73, 198, 174, 52, 184, 78]);
         assert!(compressed.is_ok());
     }
 
@@ -474,26 +463,25 @@ mod test {
         let s = Secp256k1::new();
 
         let (sk1, pk1) = s.generate_keypair(&mut thread_rng()).unwrap();
-        assert_eq!(SecretKey::from_slice(&s, &sk1[..]), Ok(sk1));
-        assert_eq!(PublicKey::from_slice(&s, &pk1.serialize_vec(&s, true)[..]), Ok(pk1));
-        assert_eq!(PublicKey::from_slice(&s, &pk1.serialize_vec(&s, false)[..]), Ok(pk1));
+        assert_eq!(SecretKey::from_slice(&sk1[..]), Ok(sk1));
+        assert_eq!(PublicKey::from_slice(&pk1.serialize_vec(true)[..]), Ok(pk1));
+        assert_eq!(PublicKey::from_slice(&pk1.serialize_vec(false)[..]), Ok(pk1));
     }
 
     #[test]
     fn invalid_secret_key() {
-        let s = Secp256k1::new();
         // Zero
-        assert_eq!(SecretKey::from_slice(&s, &[0; 32]), Err(InvalidSecretKey));
+        assert_eq!(SecretKey::from_slice(&[0; 32]), Err(InvalidSecretKey));
         // -1
-        assert_eq!(SecretKey::from_slice(&s, &[0xff; 32]), Err(InvalidSecretKey));
+        assert_eq!(SecretKey::from_slice(&[0xff; 32]), Err(InvalidSecretKey));
         // Top of range
-        assert!(SecretKey::from_slice(&s,
+        assert!(SecretKey::from_slice(
                                       &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
                                         0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE,
                                         0xBA, 0xAE, 0xDC, 0xE6, 0xAF, 0x48, 0xA0, 0x3B,
                                         0xBF, 0xD2, 0x5E, 0x8C, 0xD0, 0x36, 0x41, 0x40]).is_ok());
         // One past top of range
-        assert!(SecretKey::from_slice(&s,
+        assert!(SecretKey::from_slice(
                                       &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
                                         0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE,
                                         0xBA, 0xAE, 0xDC, 0xE6, 0xAF, 0x48, 0xA0, 0x3B,
@@ -503,7 +491,7 @@ mod test {
     #[test]
     fn test_pubkey_from_slice_bad_context() {
         let s = Secp256k1::without_caps();
-        let sk = SecretKey::new(&s, &mut thread_rng());
+        let sk = SecretKey::new(&mut thread_rng());
         assert_eq!(PublicKey::from_secret_key(&s, &sk), Err(IncapableContext));
 
         let s = Secp256k1::with_caps(ContextFlag::VerifyOnly);
@@ -693,21 +681,20 @@ mod test {
 
     #[test]
     fn test_pubkey_from_bad_slice() {
-        let s = Secp256k1::new();
         // Bad sizes
-        assert_eq!(PublicKey::from_slice(&s, &[0; constants::COMPRESSED_PUBLIC_KEY_SIZE - 1]),
+        assert_eq!(PublicKey::from_slice(&[0; constants::COMPRESSED_PUBLIC_KEY_SIZE - 1]),
                    Err(InvalidPublicKey));
-        assert_eq!(PublicKey::from_slice(&s, &[0; constants::COMPRESSED_PUBLIC_KEY_SIZE + 1]),
+        assert_eq!(PublicKey::from_slice(&[0; constants::COMPRESSED_PUBLIC_KEY_SIZE + 1]),
                    Err(InvalidPublicKey));
-        assert_eq!(PublicKey::from_slice(&s, &[0; constants::UNCOMPRESSED_PUBLIC_KEY_SIZE - 1]),
+        assert_eq!(PublicKey::from_slice(&[0; constants::UNCOMPRESSED_PUBLIC_KEY_SIZE - 1]),
                    Err(InvalidPublicKey));
-        assert_eq!(PublicKey::from_slice(&s, &[0; constants::UNCOMPRESSED_PUBLIC_KEY_SIZE + 1]),
+        assert_eq!(PublicKey::from_slice(&[0; constants::UNCOMPRESSED_PUBLIC_KEY_SIZE + 1]),
                    Err(InvalidPublicKey));
 
         // Bad parse
-        assert_eq!(PublicKey::from_slice(&s, &[0xff; constants::UNCOMPRESSED_PUBLIC_KEY_SIZE]),
+        assert_eq!(PublicKey::from_slice(&[0xff; constants::UNCOMPRESSED_PUBLIC_KEY_SIZE]),
                    Err(InvalidPublicKey));
-        assert_eq!(PublicKey::from_slice(&s, &[0x55; constants::COMPRESSED_PUBLIC_KEY_SIZE]),
+        assert_eq!(PublicKey::from_slice(&[0x55; constants::COMPRESSED_PUBLIC_KEY_SIZE]),
                    Err(InvalidPublicKey));
     }
 
@@ -754,9 +741,9 @@ mod test {
 
         let s = Secp256k1::new();
         let (_, pk1) = s.generate_keypair(&mut DumbRng(0)).unwrap();
-        assert_eq!(&pk1.serialize_vec(&s, false)[..],
+        assert_eq!(&pk1.serialize_vec(false)[..],
                    &[4, 124, 121, 49, 14, 253, 63, 197, 50, 39, 194, 107, 17, 193, 219, 108, 154, 126, 9, 181, 248, 2, 12, 149, 233, 198, 71, 149, 134, 250, 184, 154, 229, 185, 28, 165, 110, 27, 3, 162, 126, 238, 167, 157, 242, 221, 76, 251, 237, 34, 231, 72, 39, 245, 3, 191, 64, 111, 170, 117, 103, 82, 28, 102, 163][..]);
-        assert_eq!(&pk1.serialize_vec(&s, true)[..],
+        assert_eq!(&pk1.serialize_vec(true)[..],
                    &[3, 124, 121, 49, 14, 253, 63, 197, 50, 39, 194, 107, 17, 193, 219, 108, 154, 126, 9, 181, 248, 2, 12, 149, 233, 198, 71, 149, 134, 250, 184, 154, 229][..]);
     }
 
@@ -768,12 +755,12 @@ mod test {
         let (mut sk2, mut pk2) = s.generate_keypair(&mut thread_rng()).unwrap();
 
         assert_eq!(PublicKey::from_secret_key(&s, &sk1).unwrap(), pk1);
-        assert!(sk1.add_assign(&s, &sk2).is_ok());
+        assert!(sk1.add_assign(&sk2).is_ok());
         assert!(pk1.add_exp_assign(&s, &sk2).is_ok());
         assert_eq!(PublicKey::from_secret_key(&s, &sk1).unwrap(), pk1);
 
         assert_eq!(PublicKey::from_secret_key(&s, &sk2).unwrap(), pk2);
-        assert!(sk2.add_assign(&s, &sk1).is_ok());
+        assert!(sk2.add_assign(&sk1).is_ok());
         assert!(pk2.add_exp_assign(&s, &sk1).is_ok());
         assert_eq!(PublicKey::from_secret_key(&s, &sk2).unwrap(), pk2);
     }
@@ -786,12 +773,12 @@ mod test {
         let (mut sk2, mut pk2) = s.generate_keypair(&mut thread_rng()).unwrap();
 
         assert_eq!(PublicKey::from_secret_key(&s, &sk1).unwrap(), pk1);
-        assert!(sk1.mul_assign(&s, &sk2).is_ok());
+        assert!(sk1.mul_assign(&sk2).is_ok());
         assert!(pk1.mul_assign(&s, &sk2).is_ok());
         assert_eq!(PublicKey::from_secret_key(&s, &sk1).unwrap(), pk1);
 
         assert_eq!(PublicKey::from_secret_key(&s, &sk2).unwrap(), pk2);
-        assert!(sk2.mul_assign(&s, &sk1).is_ok());
+        assert!(sk2.mul_assign(&sk1).is_ok());
         assert!(pk2.mul_assign(&s, &sk1).is_ok());
         assert_eq!(PublicKey::from_secret_key(&s, &sk2).unwrap(), pk2);
     }
@@ -803,7 +790,7 @@ mod test {
         let (sk1, mut pk1) = s.generate_keypair(&mut thread_rng()).unwrap();
         let (sk2, mut pk2) = s.generate_keypair(&mut thread_rng()).unwrap();
 
-        let combined_pk = PublicKey::from_combination(&s, vec![&pk1,&pk2]).unwrap();
+        let combined_pk = PublicKey::from_combination(vec![&pk1,&pk2]).unwrap();
 
         let _ = pk2.add_exp_assign(&s, &sk1);
         let _ = pk1.add_exp_assign(&s, &sk2);
@@ -815,26 +802,26 @@ mod test {
     fn test_inverse() {
         let s = Secp256k1::new();
 
-        let one = SecretKey::from_slice(&s, &[
+        let one = SecretKey::from_slice(&[
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]).unwrap();
 
         let mut one_inv: SecretKey = one.clone();
-        one_inv.inv_assign(&s).unwrap();
+        one_inv.inv_assign().unwrap();
         assert_eq!(one_inv, one);
 
         let (sk1, _) = s.generate_keypair(&mut thread_rng()).unwrap();
         let mut sk2: SecretKey = sk1.clone();
-        sk2.inv_assign(&s).unwrap();
-        sk2.inv_assign(&s).unwrap();
+        sk2.inv_assign().unwrap();
+        sk2.inv_assign().unwrap();
         assert_eq!(sk2, sk1);
 
         let (sk1, _) = s.generate_keypair(&mut thread_rng()).unwrap();
         let mut sk2: SecretKey = sk1.clone();
-        sk2.inv_assign(&s).unwrap();
-        sk2.mul_assign(&s, &sk1).unwrap();
+        sk2.inv_assign().unwrap();
+        sk2.mul_assign(&sk1).unwrap();
         assert_eq!(sk2, one);
     }
 
@@ -844,26 +831,26 @@ mod test {
 
         let (sk1, _) = s.generate_keypair(&mut thread_rng()).unwrap();
         let mut sk2: SecretKey = sk1.clone();
-        sk2.neg_assign(&s).unwrap();
-        assert!(sk2.add_assign(&s, &sk1).is_err());
+        sk2.neg_assign().unwrap();
+        assert!(sk2.add_assign(&sk1).is_err());
 
         let (sk1, _) = s.generate_keypair(&mut thread_rng()).unwrap();
         let mut sk2: SecretKey = sk1.clone();
-        sk2.neg_assign(&s).unwrap();
-        sk2.neg_assign(&s).unwrap();
+        sk2.neg_assign().unwrap();
+        sk2.neg_assign().unwrap();
         assert_eq!(sk2, sk1);
 
         let (mut sk1, _) = s.generate_keypair(&mut thread_rng()).unwrap();
         let mut sk2: SecretKey = sk1.clone();
-        sk1.neg_assign(&s).unwrap();
+        sk1.neg_assign().unwrap();
         let sk1_clone = sk1.clone();
-        sk1.add_assign(&s, &sk1_clone).unwrap();
+        sk1.add_assign(&sk1_clone).unwrap();
         let sk2_clone = sk2.clone();
-        sk2.add_assign(&s, &sk2_clone).unwrap();
-        sk2.neg_assign(&s).unwrap();
+        sk2.add_assign(&sk2_clone).unwrap();
+        sk2.neg_assign().unwrap();
         assert_eq!(sk2, sk1);
 
-        let one = SecretKey::from_slice(&s, &[
+        let one = SecretKey::from_slice(&[
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -871,17 +858,17 @@ mod test {
 
         let (mut sk1, _) = s.generate_keypair(&mut thread_rng()).unwrap();
         let mut sk2: SecretKey = one.clone();
-        sk2.neg_assign(&s).unwrap();
-        sk2.mul_assign(&s, &sk1).unwrap();
-        sk1.neg_assign(&s).unwrap();
+        sk2.neg_assign().unwrap();
+        sk2.mul_assign(&sk1).unwrap();
+        sk1.neg_assign().unwrap();
         assert_eq!(sk2, sk1);
 
         let (mut sk1, _) = s.generate_keypair(&mut thread_rng()).unwrap();
         let mut sk2: SecretKey = sk1.clone();
-        sk1.neg_assign(&s).unwrap();
-        sk1.inv_assign(&s).unwrap();
-        sk2.inv_assign(&s).unwrap();
-        sk2.neg_assign(&s).unwrap();
+        sk1.neg_assign().unwrap();
+        sk1.inv_assign().unwrap();
+        sk2.inv_assign().unwrap();
+        sk2.neg_assign().unwrap();
         assert_eq!(sk2, sk1);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -615,7 +615,7 @@ impl Secp256k1 {
     #[inline]
     pub fn generate_keypair<R: Rng>(&self, rng: &mut R)
                                    -> Result<(key::SecretKey, key::PublicKey), Error> {
-        let sk = key::SecretKey::new(self, rng);
+        let sk = key::SecretKey::new(rng);
         let pk = key::PublicKey::from_secret_key(self, &sk)?;
         Ok((sk, pk))
     }
@@ -760,9 +760,9 @@ mod tests {
         assert_eq!(full.recover(&msg, &sigr), Ok(pk));
 
         // Check that we can produce keys from slices with no precomputation
-        let (pk_slice, sk_slice) = (&pk.serialize_vec(&none, true), &sk[..]);
-        let new_pk = PublicKey::from_slice(&none, pk_slice).unwrap();
-        let new_sk = SecretKey::from_slice(&none, sk_slice).unwrap();
+        let (pk_slice, sk_slice) = (&pk.serialize_vec(true), &sk[..]);
+        let new_pk = PublicKey::from_slice(pk_slice).unwrap();
+        let new_sk = SecretKey::from_slice(sk_slice).unwrap();
         assert_eq!(sk, new_sk);
         assert_eq!(pk, new_pk);
     }
@@ -792,7 +792,7 @@ mod tests {
         let one = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
 
-        let sk = SecretKey::from_slice(&s, &one).unwrap();
+        let sk = SecretKey::from_slice(&one).unwrap();
         let msg = Message::from_slice(&one).unwrap();
 
         let sig = s.sign_recoverable(&msg, &sk).unwrap();
@@ -893,7 +893,7 @@ mod tests {
         wild_keys[1][0] -= 1;
         wild_msgs[1][0] -= 1;
 
-        for key in wild_keys.iter().map(|k| SecretKey::from_slice(&s, &k[..]).unwrap()) {
+        for key in wild_keys.iter().map(|k| SecretKey::from_slice(&k[..]).unwrap()) {
             for msg in wild_msgs.iter().map(|m| Message::from_slice(&m[..]).unwrap()) {
                 let sig = s.sign(&msg, &key).unwrap();
                 let pk = PublicKey::from_secret_key(&s, &key).unwrap();
@@ -1039,7 +1039,7 @@ mod tests {
 
         let secp = Secp256k1::new();
         let mut sig = Signature::from_der(&secp, &sig[..]).unwrap();
-        let pk = PublicKey::from_slice(&secp, &pk[..]).unwrap();
+        let pk = PublicKey::from_slice(&pk[..]).unwrap();
         let msg = Message::from_slice(&msg[..]).unwrap();
 
         // without normalization we expect this will fail

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -538,7 +538,7 @@ impl Secp256k1 {
 			);
 		}
 		// secp256k1 should never return an invalid private
-		SecretKey::from_slice(self, &ret)
+		SecretKey::from_slice(&ret)
 	}
 
 	/// Compute a blinding factor using a switch commitment
@@ -561,7 +561,7 @@ impl Secp256k1 {
 				1
 			)
 		}
-		SecretKey::from_slice(self, &ret)
+		SecretKey::from_slice(&ret)
 	}
 
 	/// Convenience function for generating a random nonce for a range proof.
@@ -1234,8 +1234,8 @@ mod tests {
 			secp.commit(value, blinding).unwrap()
 		}
 
-		let blind_pos = SecretKey::new(&secp, &mut thread_rng());
-		let blind_neg = SecretKey::new(&secp, &mut thread_rng());
+		let blind_pos = SecretKey::new(&mut thread_rng());
+		let blind_neg = SecretKey::new(&mut thread_rng());
 
 		// now construct blinding factor to net out appropriately
 		let blind_sum = secp.blind_sum(vec![blind_pos.clone()], vec![blind_neg.clone()]).unwrap();
@@ -1258,8 +1258,8 @@ mod tests {
 		let pos_value = 101;
 		let neg_value = 75;
 
-		let blind_pos = secp.blind_switch(pos_value, SecretKey::new(&secp, &mut thread_rng())).unwrap();
-		let blind_neg = secp.blind_switch(neg_value, SecretKey::new(&secp, &mut thread_rng())).unwrap();
+		let blind_pos = secp.blind_switch(pos_value, SecretKey::new(&mut thread_rng())).unwrap();
+		let blind_neg = secp.blind_switch(neg_value, SecretKey::new(&mut thread_rng())).unwrap();
 
 		// now construct blinding factor to net out appropriately
 		let blind_sum = secp.blind_sum(vec![blind_pos.clone()], vec![blind_neg.clone()]).unwrap();
@@ -1276,7 +1276,7 @@ mod tests {
 	// provide an api to extract a public key from a commitment
 	fn test_to_pubkey() {
 		let secp = Secp256k1::with_caps(ContextFlag::Commit);
-		let blinding = SecretKey::new(&secp, &mut thread_rng());
+		let blinding = SecretKey::new(&mut thread_rng());
 		let commit = secp.commit(5, blinding).unwrap();
 		let pubkey = commit.to_pubkey(&secp);
 		match pubkey {
@@ -1293,7 +1293,7 @@ mod tests {
 	fn test_from_pubkey() {
 		for _ in 0..100 {
 			let secp = Secp256k1::with_caps(ContextFlag::Commit);
-			let blinding = SecretKey::new(&secp, &mut thread_rng());
+			let blinding = SecretKey::new(&mut thread_rng());
 			let commit = secp.commit(1, blinding).unwrap();
 			let pubkey = commit.to_pubkey(&secp);
 			let p = match pubkey {
@@ -1326,7 +1326,7 @@ mod tests {
 	#[test]
 	fn test_sign_with_pubkey_from_commitment() {
 		let secp = Secp256k1::with_caps(ContextFlag::Commit);
-		let blinding = SecretKey::new(&secp, &mut thread_rng());
+		let blinding = SecretKey::new( &mut thread_rng());
 		let commit = secp.commit(0u64, blinding.clone()).unwrap();
 
 		let mut msg = [0u8; 32];
@@ -1354,8 +1354,8 @@ mod tests {
 			secp.commit(value, blinding).unwrap()
 		}
 
-		let blind_a = SecretKey::new(&secp, &mut thread_rng());
-		let blind_b = SecretKey::new(&secp, &mut thread_rng());
+		let blind_a = SecretKey::new(&mut thread_rng());
+		let blind_b = SecretKey::new(&mut thread_rng());
 
 		let commit_a = commit(3, blind_a.clone());
 		let commit_b = commit(2, blind_b.clone());
@@ -1380,13 +1380,13 @@ mod tests {
 		let secp = Secp256k1::with_caps(ContextFlag::Commit);
 		let rng = &mut thread_rng();
 		let value: u64 = 1;
-		let blind = SecretKey::new(&secp, rng);
+		let blind = SecretKey::new(rng);
 		let blind2 = ONE_KEY;
 		assert_eq!(secp.commit(value, blind.clone()).unwrap(), secp.commit_blind(blind2.clone(), blind.clone()).unwrap());
 		let value: u64 = 2;
-		let blind = SecretKey::new(&secp, rng);
+		let blind = SecretKey::new(rng);
 		assert_ne!(secp.commit(value, blind.clone()).unwrap(), secp.commit_blind(blind2, blind.clone()).unwrap());
-		let blind = SecretKey::new(&secp, rng);
+		let blind = SecretKey::new(rng);
 		let mut blind2 = ZERO_KEY;
 		blind2.0[30] = rng.gen::<u8>();
 		blind2.0[31] = rng.gen::<u8>();
@@ -1397,7 +1397,7 @@ mod tests {
 	#[test]
 	fn test_range_proof() {
 		let secp = Secp256k1::with_caps(ContextFlag::Commit);
-		let blinding = SecretKey::new(&secp, &mut thread_rng());
+		let blinding = SecretKey::new(&mut thread_rng());
 		let commit = secp.commit(7, blinding.clone()).unwrap();
 		let msg = ProofMessage::empty();
 		let range_proof = secp.range_proof(0, 7, blinding.clone(), commit, msg.clone());
@@ -1417,7 +1417,7 @@ mod tests {
 		assert_eq!(proof_info.value, 7);
 
 		// check we cannot rewind a range proof without the original nonce
-		let bad_nonce = SecretKey::new(&secp, &mut thread_rng());
+		let bad_nonce = SecretKey::new(&mut thread_rng());
 		let bad_info = secp.rewind_range_proof(commit, range_proof, bad_nonce);
 		assert_eq!(bad_info.success, false);
 		assert_eq!(bad_info.value, 0);
@@ -1436,7 +1436,7 @@ mod tests {
 	fn test_bullet_proof_single() {
 		// Test Bulletproofs without message
 		let secp = Secp256k1::with_caps(ContextFlag::Commit);
-		let blinding = SecretKey::new(&secp, &mut thread_rng());
+		let blinding = SecretKey::new(&mut thread_rng());
 		let value = 12345678;
 		let commit = secp.commit(value, blinding.clone()).unwrap();
 		let bullet_proof = secp.bullet_proof(value, blinding.clone(), blinding.clone(), blinding.clone(), None, None);
@@ -1462,7 +1462,7 @@ mod tests {
 		// wrong blinding
 		let value = 12345678;
 		let commit = secp.commit(value, blinding).unwrap();
-		let blinding = SecretKey::new(&secp, &mut thread_rng());
+		let blinding = SecretKey::new(&mut thread_rng());
 		let bullet_proof = secp.bullet_proof(value, blinding.clone(), blinding.clone(), blinding.clone(), None, None);
 		if !secp
 			.verify_bullet_proof(commit, bullet_proof, None)
@@ -1473,7 +1473,7 @@ mod tests {
 
 		// Commit to some extra data in the bulletproof
 		let extra_data = [0u8; 32].to_vec();
-		let blinding = SecretKey::new(&secp, &mut thread_rng());
+		let blinding = SecretKey::new(&mut thread_rng());
 		let value = 12345678;
 		let commit = secp.commit(value, blinding.clone()).unwrap();
 		let bullet_proof =
@@ -1498,9 +1498,9 @@ mod tests {
 
 		// Ensure rewinding works
 
-		let blinding = SecretKey::new(&secp, &mut thread_rng());
-		let rewind_nonce = SecretKey::new(&secp, &mut thread_rng());
-		let private_nonce = SecretKey::new(&secp, &mut thread_rng());
+		let blinding = SecretKey::new( &mut thread_rng());
+		let rewind_nonce = SecretKey::new(&mut thread_rng());
+		let private_nonce = SecretKey::new(&mut thread_rng());
 		let value = 12345678;
 		let commit = secp.commit(value, blinding.clone()).unwrap();
 
@@ -1554,9 +1554,9 @@ mod tests {
 	fn test_bullet_proof_extra() {
 
 		let secp = Secp256k1::with_caps(ContextFlag::Commit);
-		let blinding = SecretKey::new(&secp, &mut thread_rng());
+		let blinding = SecretKey::new(&mut thread_rng());
 
-		let rewind_nonce  = SecretKey::new(&secp, &mut thread_rng());
+		let rewind_nonce  = SecretKey::new(&mut thread_rng());
 		let private_nonce = rewind_nonce.clone();
 
 		let mut extra_data = [0u8; 32];
@@ -1651,8 +1651,8 @@ mod tests {
 
 				let common_nonce = nonce;
 
-				let private_nonce_a = SecretKey::new(&secp, &mut thread_rng());
-				let private_nonce_b = SecretKey::new(&secp, &mut thread_rng());
+				let private_nonce_a = SecretKey::new(&mut thread_rng());
+				let private_nonce_b = SecretKey::new(&mut thread_rng());
 
 				// 1st step on party A: generate t_one and t_two, and sends to party B
 				let mut t_one_a = PublicKey::new();
@@ -1692,15 +1692,15 @@ mod tests {
 				let mut pubkeys = vec![];
 				pubkeys.push(&t_one_a);
 				pubkeys.push(&t_one_b);
-				let mut t_one_sum = PublicKey::from_combination(&secp, pubkeys.clone()).unwrap();
+				let mut t_one_sum = PublicKey::from_combination(pubkeys.clone()).unwrap();
 
 				pubkeys.clear();
 				pubkeys.push(&t_two_a);
 				pubkeys.push(&t_two_b);
-				let mut t_two_sum = PublicKey::from_combination(&secp, pubkeys.clone()).unwrap();
+				let mut t_two_sum = PublicKey::from_combination(pubkeys.clone()).unwrap();
 
 				// 2nd step on party A: use t_one_sum and t_two_sum to generate tau_x, and sent to party B.
-				let mut tau_x_a = SecretKey::new(&secp, &mut thread_rng());
+				let mut tau_x_a = SecretKey::new(&mut thread_rng());
 				secp.bullet_proof_multisig(
 					value,
 					blinding_a.clone(),
@@ -1716,7 +1716,7 @@ mod tests {
 				);
 
 				// 2nd step on party B: use t_one_sum and t_two_sum to generate tau_x, and send to party A.
-				let mut tau_x_b = SecretKey::new(&secp, &mut thread_rng());
+				let mut tau_x_b = SecretKey::new(&mut thread_rng());
 				secp.bullet_proof_multisig(
 					value,
 					blinding_b.clone(),
@@ -1733,7 +1733,7 @@ mod tests {
 
 				// 2nd step on both party A and B: sum up both tau_x
 				let mut tau_x_sum = tau_x_a;
-				tau_x_sum.add_assign(&secp, &tau_x_b).unwrap();
+				tau_x_sum.add_assign(&tau_x_b).unwrap();
 
 				// 3rd step: party A finalizes bulletproof with input tau_x, t_one, t_two.
 				let bullet_proof =
@@ -1761,12 +1761,12 @@ mod tests {
 		let secp = Secp256k1::with_caps(ContextFlag::Commit);
 		let value: u64 = 12345678;
 
-		let common_nonce = SecretKey::new(&secp, &mut thread_rng());
+		let common_nonce = SecretKey::new(&mut thread_rng());
 
-		let blinding_a = SecretKey::new(&secp, &mut thread_rng());
+		let blinding_a = SecretKey::new(&mut thread_rng());
 		let partial_commit_a = secp.commit(value, blinding_a.clone()).unwrap();
 
-		let blinding_b = SecretKey::new(&secp, &mut thread_rng());
+		let blinding_b = SecretKey::new(&mut thread_rng());
 		let partial_commit_b = secp.commit(0, blinding_b.clone()).unwrap();
 
 		// 1. Test Bulletproofs multisig without message
@@ -1799,7 +1799,7 @@ mod tests {
 		}
 
 		// 3. wrong blinding
-		let wrong_blinding = SecretKey::new(&secp, &mut thread_rng());
+		let wrong_blinding = SecretKey::new(&mut thread_rng());
 		let (_, proof_range) = multisig_bp(
 			value,
 			common_nonce.clone(),
@@ -1910,8 +1910,8 @@ mod tests {
 	#[test]
 	fn rewind_empty_message() {
 		let secp = Secp256k1::with_caps(ContextFlag::Commit);
-		let blinding = SecretKey::new(&secp, &mut thread_rng());
-		let nonce = SecretKey::new(&secp, &mut thread_rng());
+		let blinding = SecretKey::new(&mut thread_rng());
+		let nonce = SecretKey::new(&mut thread_rng());
 		let value = <u64>::max_value() - 1;
 		let commit = secp.commit(value, blinding.clone()).unwrap();
 
@@ -1930,8 +1930,8 @@ mod tests {
 	#[test]
 	fn rewind_message() {
 		let secp = Secp256k1::with_caps(ContextFlag::Commit);
-		let blinding = SecretKey::new(&secp, &mut thread_rng());
-		let nonce = SecretKey::new(&secp, &mut thread_rng());
+		let blinding = SecretKey::new(&mut thread_rng());
+		let nonce = SecretKey::new(&mut thread_rng());
 		let value = <u64>::max_value() - 1;
 		let commit = secp.commit(value, blinding.clone()).unwrap();
 
@@ -1944,7 +1944,7 @@ mod tests {
 		assert_eq!(blinding, proof_info.blinding);
 
 		// Using a different private nonce should prevent rewind of blinding factor
-		let private_nonce = SecretKey::new(&secp, &mut thread_rng());
+		let private_nonce = SecretKey::new(&mut thread_rng());
 		let bullet_proof = secp.bullet_proof(value, blinding.clone(), nonce.clone(), private_nonce.clone(), None, None);
 		let proof_info = secp
 			.rewind_bullet_proof(commit, nonce, None, bullet_proof)
@@ -1959,7 +1959,7 @@ mod tests {
 		let nano_to_millis = 1.0 / 1_000_000.0;
 
 		let secp = Secp256k1::with_caps(ContextFlag::Commit);
-		let blinding = SecretKey::new(&secp, &mut thread_rng());
+		let blinding = SecretKey::new(&mut thread_rng());
 		let value = 12345678;
 
 		let increments = vec![1, 2, 5, 10, 100, 200];
@@ -1999,10 +1999,10 @@ mod tests {
 		let mut proofs: Vec<RangeProof> = vec![];
 
 		let secp = Secp256k1::with_caps(ContextFlag::Commit);
-		let blinding = SecretKey::new(&secp, &mut thread_rng());
-		let rewind_nonce  = SecretKey::new(&secp, &mut thread_rng());
-		let private_nonce = SecretKey::new(&secp, &mut thread_rng());
-		let wrong_blinding = SecretKey::new(&secp, &mut thread_rng());
+		let blinding = SecretKey::new(&mut thread_rng());
+		let rewind_nonce  = SecretKey::new(&mut thread_rng());
+		let private_nonce = SecretKey::new(&mut thread_rng());
+		let wrong_blinding = SecretKey::new(&mut thread_rng());
 		let value = 12345678;
 
 		let wrong_commit = secp.commit(value, wrong_blinding).unwrap();
@@ -2116,7 +2116,7 @@ mod benches {
     pub fn bench_bullet_proof_verification(bh: &mut Bencher) {
 		// Test Bulletproofs without message
 		let secp = Secp256k1::with_caps(ContextFlag::Commit);
-		let blinding = SecretKey::new(&secp, &mut thread_rng());
+		let blinding = SecretKey::new(&mut thread_rng());
 		let value = 12345678;
 		let commit = secp.commit(value, blinding.clone()).unwrap();
 		let bullet_proof = secp.bullet_proof(value, blinding.clone(), blinding.clone(), blinding.clone(), None, None);


### PR DESCRIPTION
A simple secp256k1 context object is designed for type serialization/parsing functions, no explicit context is needed to avoid expensive pre-computations or dynamic allocations.

This will give a nice improvement to avoid the secp locking for ser/deser.

For details of this PR:
1. Use simple secp256k1 context object with no pre-computed tables.
2. Switch to `mwcproject/secp256k1-zkp`, instead using  `mimblewimble/secp256k1-zkp`
3. Update `secp256k1-zkp` to latest.
4. Bump the crate version to **0.7.10** so as to avoid affecting existing usage in other dependency projects.

