### PR TITLE
change blind_sum from method to associated function

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -53,6 +53,7 @@ pub const PEDERSEN_COMMITMENT_SIZE_INTERNAL: usize = 64;
 /// The size of a single Bullet proof
 pub const SINGLE_BULLET_PROOF_SIZE: usize = 675;
 
+/// The max size of a bullet proof
 #[cfg(feature = "bullet-proof-sizing")]
 pub const MAX_PROOF_SIZE: usize = SINGLE_BULLET_PROOF_SIZE;
 /// The max size of a range proof
@@ -62,6 +63,7 @@ pub const MAX_PROOF_SIZE: usize = 5134;
 /// The maximum size of a message embedded in a range proof
 #[cfg(not(feature = "bullet-proof-sizing"))]
 pub const PROOF_MSG_SIZE: usize = 2048;
+/// The maximum size of a message embedded in a bullet proof
 #[cfg(feature = "bullet-proof-sizing")]
 pub const PROOF_MSG_SIZE: usize = 2048;
 


### PR DESCRIPTION
Change the following `Secp256k1` methods as `associated function`, i.e.  removing the `&self` parameter from its function declaration.
- `::blind_sum()`
- `::commit_sum()`
- `::verify_commit_sum()`

which obviously have no chance/need to use `precomp` table for optimization in the future.

Some methods are kept as method, as described in #6, for future optimization.
 - `::commit()`
 - `::commit_blind()`
 - `::commit_value()`
