### PR TITLE
Address audit comments:

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "mwc_secp256k1zkp"
-version = "0.7.17"
+version = "0.8.0"
 authors = [ "Mwc Developers <mimblewimble@lists.launchpad.net>",
             "Dawid Ciężarkiewicz <dpc@ucore.info>",
             "Andrew Poelstra <apoelstra@wpsoftware.net>" ]
@@ -23,19 +23,16 @@ path = "src/lib.rs"
 
 [features]
 unstable = []
-default = []
+default = ["bullet-proof-sizing"]
 bullet-proof-sizing = []
-dev = ["clippy"]
 
 [dependencies]
 arrayvec = "0.7"
-clippy = {version = "0.0", optional = true}
-rand = "0.5"
+rand = { version = "0.10", features = ["std", "sys_rng"] }
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-zeroize = { version = "1.1", features = ["zeroize_derive"] }
+zeroize = { version = "1.8", features = ["zeroize_derive"] }
 
 [dev-dependencies]
-chrono = "0.4.5"
-rand_core = "0.2"
+chrono = "0.4"

--- a/build.rs
+++ b/build.rs
@@ -21,12 +21,13 @@
 #![deny(unused_mut)]
 #![warn(missing_docs)]
 
-fn main() {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut base_config = cc::Build::new();
     base_config.include("depend/secp256k1-zkp/")
                .include("depend/secp256k1-zkp/include")
                .include("depend/secp256k1-zkp/src")
-               .flag("-g")
+                // -g is for debug. Removing for release build
+                //.flag("-g")
                // TODO these three should be changed to use libgmp, at least until secp PR 290 is merged
                .define("USE_NUM_NONE", Some("1"))
                .define("USE_FIELD_INV_BUILTIN", Some("1"))
@@ -48,10 +49,11 @@ fn main() {
     base_config.file("depend/secp256k1-zkp/contrib/lax_der_parsing.c")
                .file("depend/secp256k1-zkp/src/secp256k1.c");
 
-    let compiler = base_config.get_compiler();
+    let compiler = base_config.try_get_compiler()?;
     if compiler.is_like_gnu() || compiler.is_like_clang() {
         base_config.flag("-Wno-unused-function");
     }
 
-    base_config.compile("libsecp256k1.a");
+    base_config.try_compile("libsecp256k1.a")?;
+    Ok(())
 }

--- a/fuzz/fuzz_targets/fuzz_aggsig.rs
+++ b/fuzz/fuzz_targets/fuzz_aggsig.rs
@@ -13,7 +13,8 @@ use secp256k1zkp::{
 };
 
 use secp256k1zkp::aggsig::AggSigContext;
-use secp256k1zkp::rand::{Rng, thread_rng};
+use secp256k1zkp::rand::TryRng;
+use secp256k1zkp::rand::rngs::SysRng;
 
 fuzz_target!(|data: &[u8]| {
     let numkeys = 3;
@@ -21,8 +22,8 @@ fuzz_target!(|data: &[u8]| {
         return ();
     }
 
-    let mut rng = thread_rng();
-    let secp = Secp256k1::with_caps(ContextFlag::Full);
+    let mut rng = &mut SysRng;
+    let secp = Secp256k1::with_caps(ContextFlag::Full).unwrap();
     let mut pks: Vec<PublicKey> = Vec::with_capacity(numkeys);
     let mut keypairs: Vec<(SecretKey, PublicKey)> = Vec::with_capacity(numkeys);
 
@@ -32,22 +33,24 @@ fuzz_target!(|data: &[u8]| {
             pks.push(pk.clone());
             keypairs.push((sk, pk));
         } else {
+            // Invalid data if regenarated intentionally. As a result, tests will not be reproducable, it is accepted.
+            // The harness is not input-deterministic - it is expected
             let (sk, pk) = secp.generate_keypair(&mut rng).unwrap();
             pks.push(pk.clone());
             keypairs.push((sk, pk));
         }
     }
 
-    let aggsig = AggSigContext::new(&secp, &pks);
+    let mut aggsig = AggSigContext::new(&pks).unwrap();
 
     for i in 0..numkeys {
-        if aggsig.generate_nonce(i) != true {
+        if aggsig.generate_nonce(i).unwrap() != true {
             panic!("failed to generate aggsig nonce: {}", i);
         }
     }
 
     let mut msg_in = [0u8; 32];
-    rng.fill(&mut msg_in);
+    rng.try_fill_bytes(&mut msg_in).unwrap();
     let msg = Message::from_slice(&msg_in).unwrap();
  
     let mut partial_sigs: Vec<AggSigPartialSignature> = vec![];
@@ -60,7 +63,12 @@ fuzz_target!(|data: &[u8]| {
     }
 
     match aggsig.combine_signatures(&partial_sigs) {
-        Ok(full_sig) => { let _ = aggsig.verify(full_sig, msg.clone(), &pks); () },
+        Ok(full_sig) => {
+            if !aggsig.verify(full_sig, msg.clone()).unwrap() {
+                panic!("aggsig.verify return false")
+            }
+            ()
+        },
         Err(e) => panic!("error combining signatures: {:?}", e),
     }
 });

--- a/fuzz/fuzz_targets/fuzz_ecdh.rs
+++ b/fuzz/fuzz_targets/fuzz_ecdh.rs
@@ -11,11 +11,11 @@ fuzz_target!(|data: &[u8]| {
         return ();
     }
 
-    let s = Secp256k1::new();
+    let s = Secp256k1::new().unwrap();
 
     if let Ok(sk) = SecretKey::from_slice(&s, &data[..32]) {
         match PublicKey::from_secret_key(&s, &sk) {
-            Ok(pk) => { let _ = SharedSecret::new(&s, &pk, &sk); () },
+            Ok(pk) => { SharedSecret::new(&s, &pk, &sk).unwrap(); () },
             Err(e) => panic!("cannot create public key from secret: {}", e),
         }
     }

--- a/fuzz/fuzz_targets/fuzz_sign.rs
+++ b/fuzz/fuzz_targets/fuzz_sign.rs
@@ -10,7 +10,7 @@ fuzz_target!(|data: &[u8]| {
         return ();
     }
 
-    let s = Secp256k1::new();
+    let s = Secp256k1::new().unwrap();
 
     let msg = Message::from_slice(&data[..32]).unwrap();
 

--- a/src/aggsig.rs
+++ b/src/aggsig.rs
@@ -14,12 +14,14 @@
 //! # Aggregated Signature (a.k.a. Schnorr) Functionality
 
 use libc::size_t;
-use crate::ffi;
+use crate::{constants, ffi, ContextFlag};
 use crate::key::{PublicKey, SecretKey};
-use rand::{thread_rng, Rng};
 use std::ptr;
 use crate::Secp256k1;
-use crate::{AggSigPartialSignature, Error, Message, Signature};
+use crate::{AggSigPartialSignature, AggSigSignature, Error, Message};
+use zeroize::Zeroize;
+use rand::rngs::SysRng;
+use rand::TryRng;
 
 const SCRATCH_SPACE_SIZE: size_t = 1024 * 1024;
 
@@ -34,9 +36,15 @@ pub const ZERO_256: [u8; 32] = [
 /// msg: the message to sign
 /// seckey: the secret key
 pub fn export_secnonce_single(secp: &Secp256k1) -> Result<SecretKey, Error> {
-	let mut return_key = SecretKey::new(&secp, &mut thread_rng());
+	if secp.caps == ContextFlag::VerifyOnly || secp.caps == ContextFlag::None {
+		return Err(Error::IncapableContext);
+	}
+
+	let mut return_key : [u8; constants::SECRET_KEY_SIZE] = [0u8; constants::SECRET_KEY_SIZE];
 	let mut seed = [0u8; 32];
-	thread_rng().fill(&mut seed);
+	SysRng.try_fill_bytes(&mut seed)
+		.map_err(|_| Error::SysRngFailure)?;
+
 	let retval = unsafe {
 		ffi::secp256k1_aggsig_export_secnonce_single(
 			secp.ctx,
@@ -44,46 +52,49 @@ pub fn export_secnonce_single(secp: &Secp256k1) -> Result<SecretKey, Error> {
 			seed.as_ptr(),
 		)
 	};
-	if retval == 0 {
-		return Err(Error::InvalidSignature);
+	seed.zeroize();
+	if retval != 1 {
+		return Err(Error::NonceExportError);
 	}
+
+	let return_key = SecretKey::from_slice(secp, &return_key)?;
 	Ok(return_key)
 }
 
-// This is a macro that check zero public key
-macro_rules! is_zero_pubkey {
-	(reterr => $e:expr) => {
+macro_rules! is_valid_pubkey {
+	(reterr => $secp:expr, $e:expr) => {
 		match $e {
 			Some(n) => {
-				if (n.0).0.starts_with(&ZERO_256) {
+				if !n.is_valid($secp) {
 					return Err(Error::InvalidPublicKey);
-					}
-				n.as_ptr()
 				}
+				n.as_ptr()
+			},
 			None => ptr::null(),
-			}
+		}
 	};
-	(retfalse => $e:expr) => {
+	(retfalse => $secp:expr, $e:expr) => {
 		match $e {
 			Some(n) => {
-				if (n.0).0.starts_with(&ZERO_256) {
-					return false;
-					}
-				n.as_ptr()
+				if !n.is_valid($secp) {
+					return Ok(false);
 				}
+				n.as_ptr()
+			},
 			None => ptr::null(),
-			}
+		}
 	};
 }
 
 /// Single-Signer (plain old Schnorr, sans-multisig) signature creation
-/// Returns: Ok(Signature) on success
+/// Returns: Ok(AggSigSignature) on success
 /// In:
 /// msg: the message to sign
 /// seckey: the secret key
 /// extra: if Some(), add this key to s
 /// secnonce: if Some(SecretKey), the secret nonce to use. If None, generate a nonce
 /// pubnonce: if Some(PublicKey), overrides the public nonce to encode as part of e
+/// pubkey_for_e: public key material to encode as part of e; must be supplied
 /// final_nonce_sum: if Some(PublicKey), overrides the public nonce to encode as part of e
 pub fn sign_single(
 	secp: &Secp256k1,
@@ -92,28 +103,40 @@ pub fn sign_single(
 	secnonce: Option<&SecretKey>,
 	extra: Option<&SecretKey>,
 	pubnonce: Option<&PublicKey>,
-	pubkey_for_e: Option<&PublicKey>,
+	pubkey_for_e: &PublicKey,
 	final_nonce_sum: Option<&PublicKey>,
-) -> Result<Signature, Error> {
-	let mut retsig = Signature::from(ffi::Signature::new());
-	let mut seed = [0u8; 32];
-	thread_rng().fill(&mut seed);
+) -> Result<AggSigSignature, Error> {
+	if secp.caps == ContextFlag::VerifyOnly || secp.caps == ContextFlag::None {
+		return Err(Error::IncapableContext);
+	}
+
+	let mut retsig = AggSigSignature::new();
 
 	let secnonce = match secnonce {
 		Some(n) => n.as_ptr(),
 		None => ptr::null(),
 	};
 
-	let pubnonce = is_zero_pubkey!(reterr => pubnonce);
+	let pubnonce = is_valid_pubkey!(reterr => secp, pubnonce);
 
 	let extra = match extra {
 		Some(e) => e.as_ptr(),
 		None => ptr::null(),
 	};
 
-	let final_nonce_sum = is_zero_pubkey!(reterr => final_nonce_sum);
+	let final_nonce_sum = is_valid_pubkey!(reterr => secp, final_nonce_sum);
 
-	let pe = is_zero_pubkey!(reterr => pubkey_for_e);
+	if !pubkey_for_e.is_valid(secp) {
+		return Err(Error::InvalidPublicKey);
+	}
+	let pe = pubkey_for_e.as_ptr();
+
+	// Note, seed it needed only if secnonce_final_nonce_sum is not provided.
+	// But let's not make assumptions about secp256k1_aggsig_sign_single internals that
+	// that can be changed and generate seed every time.
+	let mut seed = [0u8; 32];
+	SysRng.try_fill_bytes(&mut seed)
+		.map_err(|_| Error::SysRngFailure)?;
 
 	let retval = unsafe {
 		ffi::secp256k1_aggsig_sign_single(
@@ -129,50 +152,66 @@ pub fn sign_single(
 			seed.as_ptr(),
 		)
 	};
-	if retval == 0 {
+	seed.zeroize();
+	if retval != 1 {
+		return Err(Error::InvalidSignature);
+	}
+	if !retsig.is_valid(secp) {
 		return Err(Error::InvalidSignature);
 	}
 	Ok(retsig)
 }
 
 /// Single-Signer (plain old Schnorr, sans-multisig) signature verification
-/// Returns: Ok(Signature) on success
+/// Returns: Ok(bool) on success
 /// In:
 /// sig: The signature
 /// msg: the message to verify
 /// pubnonce: if Some(PublicKey) overrides the public nonce used to calculate e
 /// pubkey: the public key
-/// pubkey_total: The total of all public keys (for the message in e)
+/// pubkey_total: The total of all public keys included in the message challenge e
 /// is_partial: whether this is a partial sig, or a fully-combined sig
+/// Note: invalid public keys and signatures are not reported as an error.
+///    they are reported and invalid signature. Idea that user can pass any combinations of
+///    PK and Signatures so we need to varify them, no extra details are expected.
+/// Note: Validation internal error will be reported as false
 pub fn verify_single(
 	secp: &Secp256k1,
-	sig: &Signature,
+	sig: &AggSigSignature,
 	msg: &Message,
 	pubnonce: Option<&PublicKey>,
 	pubkey: &PublicKey,
-	pubkey_total_for_e: Option<&PublicKey>,
+	pubkey_total_for_e: &PublicKey,
 	extra_pubkey: Option<&PublicKey>,
 	is_partial: bool,
-) -> bool {
-	let pubnonce = is_zero_pubkey!(retfalse => pubnonce);
+) -> Result<bool, Error> {
+	if secp.caps == ContextFlag::SignOnly || secp.caps == ContextFlag::None {
+		return Err(Error::IncapableContext);
+	}
 
-	let pe = is_zero_pubkey!(retfalse => pubkey_total_for_e);
+	let pubnonce = is_valid_pubkey!(retfalse => secp, pubnonce);
+	let extra = is_valid_pubkey!(retfalse => secp, extra_pubkey);
 
-	let extra = is_zero_pubkey!(retfalse => extra_pubkey);
+	if !pubkey.is_valid(secp) {
+		return Ok(false);
+	}
+	if !pubkey_total_for_e.is_valid(secp) {
+		return Ok(false);
+	}
+	if !sig.is_valid(secp) {
+		return Ok(false);
+	}
+	let pe = pubkey_total_for_e.as_ptr();
 
 	let is_partial = match is_partial {
 		true => 1,
 		false => 0,
 	};
 
-	if (sig.0).0.starts_with(&ZERO_256) || (pubkey.0).0.starts_with(&ZERO_256) {
-		return false;
-	}
-
 	let retval = unsafe {
 		ffi::secp256k1_aggsig_verify_single(
 			secp.ctx,
-			sig.as_ptr(),
+			sig.0.as_ptr(),
 			msg.as_ptr(),
 			pubnonce,
 			pubkey.as_ptr(),
@@ -181,42 +220,62 @@ pub fn verify_single(
 			is_partial,
 		)
 	};
-	match retval {
-		0 => false,
-		1 => true,
-		_ => false,
-	}
+	// Note: Validation internal error will be reported as false, chances of false negative are accepted
+	Ok(retval==1)
 }
 
 
 /// Batch Schnorr signature verification
 /// Returns: true on success
 /// In:
-/// sigs: The signatures
+/// sigs: The aggsig signatures
 /// msg: The messages to verify
 /// pubkey: The public keys
+/// Note, return false might happens because of internal errors.
 pub fn verify_batch(
 	secp: &Secp256k1,
-	sigs: &Vec<Signature>,
+	sigs: &Vec<AggSigSignature>,
 	msgs: &Vec<Message>,
 	pub_keys: &Vec<PublicKey>,
-) -> bool {
-	if sigs.len() != msgs.len() || sigs.len() != pub_keys.len() {
-		return false;
+) -> Result<bool,Error> {
+	if secp.caps == ContextFlag::SignOnly || secp.caps == ContextFlag::None {
+		return Err(Error::IncapableContext);
 	}
 
-	for i in 0..pub_keys.len() {
-		if (pub_keys[i].0).0.starts_with(&ZERO_256) {
-			return false;
+	if sigs.len() > 1048575 {
+		return Err(Error::InvalidParameters);
+	}
+
+	if sigs.len() != msgs.len() || sigs.len() != pub_keys.len() {
+		// Intentionally response as false, not an error.
+		return Ok(false);
+	}
+
+	for pk in pub_keys {
+		if !pk.is_valid(secp) {
+			// Intentionally response as false, not an error.
+			return Ok(false);
+		}
+	}
+	for sig in sigs {
+		if !sig.is_valid(secp) {
+			// Intentionally response as false, not an error.
+			return Ok(false);
 		}
 	}
 
-	let sigs_vec = map_vec!(sigs, |s| s.0.as_ptr());
+	let sigs_vec = map_vec!(sigs, |s| s.as_ptr());
 	let msgs_vec = map_vec!(msgs, |m| m.as_ptr());
 	let pub_keys_vec = map_vec!(pub_keys, |pk| pk.as_ptr());
 
 	unsafe {
 		let scratch = ffi::secp256k1_scratch_space_create(secp.ctx, SCRATCH_SPACE_SIZE);
+		// Note ffi::secp256k1_scratch_space_create will not return the NULL, it will crash instead.
+		//  Checking for null for extra layer
+
+		if scratch.is_null() {
+			return Err(Error::AllocationError);
+		}
 		let result = ffi::secp256k1_schnorrsig_verify_batch(
 			secp.ctx,
 			scratch,
@@ -226,23 +285,41 @@ pub fn verify_batch(
 			sigs.len(),
 		);
 		ffi::secp256k1_scratch_space_destroy(scratch);
-		result == 1
+		// Note, return false might happens because of internal errors.
+		// result==0 might be because of internal error
+		Ok(result == 1)
 	}
 }
 
 /// Single-Signer addition of Signatures
-/// Returns: Ok(Signature) on success
+/// Returns: Ok(AggSigSignature) on success
 /// In:
 /// sig1: sig1 to add
 /// sig2: sig2 to add
 /// pubnonce_total: sum of public nonces
 pub fn add_signatures_single(
 	secp: &Secp256k1,
-	sigs: Vec<&Signature>,
+	sigs: Vec<&AggSigSignature>,
 	pubnonce_total: &PublicKey,
-) -> Result<Signature, Error> {
-	let mut retsig = Signature::from(ffi::Signature::new());
-	let sig_vec = map_vec!(sigs, |s| s.0.as_ptr());
+) -> Result<AggSigSignature, Error> {
+	if secp.caps == ContextFlag::VerifyOnly || secp.caps == ContextFlag::None {
+		return Err(Error::IncapableContext);
+	}
+
+	if sigs.is_empty() {
+		return Err(Error::InvalidParameters);
+	}
+	if !pubnonce_total.is_valid(secp) {
+		return Err(Error::InvalidPublicKey);
+	}
+	for sig in &sigs {
+		if !sig.is_valid(secp) {
+			return Err(Error::InvalidSignature);
+		}
+	}
+
+	let mut retsig = AggSigSignature::new();
+	let sig_vec = map_vec!(sigs, |s| s.as_ptr());
 	let retval = unsafe {
 		ffi::secp256k1_aggsig_add_signatures_single(
 			secp.ctx,
@@ -252,25 +329,30 @@ pub fn add_signatures_single(
 			pubnonce_total.as_ptr(),
 		)
 	};
-	if retval == 0 {
+	if retval != 1 || !retsig.is_valid(secp) {
 		return Err(Error::InvalidSignature);
 	}
 	Ok(retsig)
 }
 
 /// Subtraction of partial signature from a signature
-/// Returns: Ok((Signature, None)) on success if the resulting signature has only one possibility
-///          Ok((Signature, Signature)) on success if the resulting signature could be one of either possiblity
+/// Returns: Ok((AggSigSignature, None)) on success if the resulting signature has only one possibility
+///          Ok((AggSigSignature, AggSigSignature)) on success if the resulting signature could be one of either possiblity
 /// In:
 /// sig: completed signature from which to subtact a partial
 /// partial_sig: the partial signature to subtract
 pub fn subtract_partial_signature(
 	secp: &Secp256k1,
-	sig: &Signature,
-	partial_sig: &Signature,
-) -> Result<(Signature, Option<Signature>), Error> {
-	let mut ret_partsig = Signature::from(ffi::Signature::new());
-	let mut ret_partsig_alt = Signature::from(ffi::Signature::new());
+	sig: &AggSigSignature,
+	partial_sig: &AggSigSignature,
+) -> Result<(AggSigSignature, Option<AggSigSignature>), Error> {
+	if !sig.is_valid(secp) || !partial_sig.is_valid(secp) {
+		return Err(Error::InvalidSignature);
+	}
+
+	// Here we are passing to secp256k1_aggsig_subtract_partial_signature two zero initialized buffers: [0; 64]
+	let mut ret_partsig = AggSigSignature::new();
+	let mut ret_partsig_alt = AggSigSignature::new();
 	let retval = unsafe {
 		ffi::secp256k1_aggsig_subtract_partial_signature(
 			secp.ctx,
@@ -283,53 +365,103 @@ pub fn subtract_partial_signature(
 
 	match retval {
 		-1 => Err(Error::SigSubtractionFailure),
-		1 => Ok((ret_partsig, None)),
-		2 => Ok((ret_partsig, Some(ret_partsig_alt))),
-		_ => Err(Error::InvalidSignature)
+		1 => {
+			if !ret_partsig.is_valid(secp) {
+				Err(Error::InvalidSignature)
+			}
+			else {
+				Ok((ret_partsig, None))
+			}
+		},
+		2 => {
+			if !ret_partsig.is_valid(secp) || !ret_partsig_alt.is_valid(secp) {
+				Err(Error::InvalidSignature)
+			}
+			else {
+				Ok((ret_partsig, Some(ret_partsig_alt)))
+			}
+		},
+		_ => Err(Error::GenericError)
 	}
 }
 
 
 /// Manages an instance of an aggsig multisig context, and provides all methods
 /// to act on that context
-#[derive(Clone, Debug)]
+/// Note, Clone can't be supported because of Drop that release aggsig_ctx
+#[derive(Debug)]
 pub struct AggSigContext {
-	ctx: *mut ffi::Context,
+	secp: Option<Secp256k1>,
 	aggsig_ctx: *mut ffi::AggSigContext,
+	pubkeys: Vec<PublicKey>,
 }
 
 impl AggSigContext {
+	#[inline]
+	fn has_valid_index(&self, index: usize) -> bool {
+		index < self.pubkeys.len()
+	}
+
 	/// Creates new aggsig context with a new random seed
-	pub fn new(secp: &Secp256k1, pubkeys: &Vec<PublicKey>) -> AggSigContext {
-		let mut seed = [0u8; 32];
-		thread_rng().fill(&mut seed);
-		let pubkeys: Vec<*const ffi::PublicKey> = pubkeys.into_iter().map(|p| p.as_ptr()).collect();
-		let pubkeys = &pubkeys[..];
-		unsafe {
-			AggSigContext {
-				ctx: secp.ctx,
-				aggsig_ctx: ffi::secp256k1_aggsig_context_create(
-					secp.ctx,
-					pubkeys[0],
-					pubkeys.len(),
-					seed.as_ptr(),
-				),
-			}
+	pub fn new(pubkeys: &Vec<PublicKey>) -> Result<AggSigContext, Error> {
+		if pubkeys.is_empty() || pubkeys.len()>1048575 {
+			return Err(Error::InvalidParameters)
 		}
+
+		let secp = Secp256k1::with_caps(ContextFlag::Full)?;
+
+		let mut ffi_pubkeys: Vec<ffi::PublicKey> = Vec::with_capacity(pubkeys.len());
+		for pk in pubkeys {
+			if !pk.is_valid(&secp) {
+				return Err(Error::InvalidPublicKey);
+			}
+			ffi_pubkeys.push(pk.as_ffi());
+		}
+
+		let mut seed = [0u8; 32];
+		SysRng.try_fill_bytes(&mut seed)
+			.map_err(|_| Error::SysRngFailure)?;
+
+		let aggsig_ctx = unsafe {
+			ffi::secp256k1_aggsig_context_create(
+				secp.ctx,
+				ffi_pubkeys.as_ptr(),
+				ffi_pubkeys.len(),
+				seed.as_ptr(),
+			)
+		};
+		seed.zeroize();
+
+		// Note, normally ffi::secp256k1_aggsig_context_create will never return null, it will crash instead.
+		// There is nothing what we can do about that.
+		if aggsig_ctx.is_null() {
+			return Err(Error::AllocationError);
+		}
+
+		Ok(AggSigContext {
+				secp: Some(secp),
+				aggsig_ctx,
+				pubkeys: pubkeys.clone(),
+			})
 	}
 
 	/// Generate a nonce pair for a single signature part in an aggregated signature
 	/// Returns: true on success
-	///          false if a nonce has already been generated for this index
+	///          false if a nonce has already been generated for this index or internal error happens
 	/// In: index: which signature to generate a nonce for
-	pub fn generate_nonce(&self, index: usize) -> bool {
-		let retval =
-			unsafe { ffi::secp256k1_aggsig_generate_nonce(self.ctx, self.aggsig_ctx, index) };
-		match retval {
-			0 => false,
-			1 => true,
-			_ => false,
+	/// Note: since 'nonce has already been generated' and 'internal error during generation' mean that
+	///     nonce must be rejected, we don't need distinguish those events for caller.
+	/// Note: generate_nonce using cached data from the self.secp context.
+	pub fn generate_nonce(&self, index: usize) -> Result<bool, Error> {
+		if !self.has_valid_index(index) {
+			return Err(Error::InvalidParameters);
 		}
+		let secp = self.secp.as_ref().ok_or(Error::BrokenAggSigContext)?;
+
+		let retval =
+			unsafe { ffi::secp256k1_aggsig_generate_nonce(secp.ctx, self.aggsig_ctx, index) };
+
+		Ok(retval == 1)
 	}
 
 	/// Generate a single signature part in an aggregated signature
@@ -339,15 +471,21 @@ impl AggSigContext {
 	/// seckey: the secret key
 	/// index: which index to generate a partial sig for
 	pub fn partial_sign(
-		&self,
+		&mut self,
 		msg: Message,
 		seckey: SecretKey,
 		index: usize,
 	) -> Result<AggSigPartialSignature, Error> {
+		if !self.has_valid_index(index) {
+			return Err(Error::InvalidParameters);
+		}
+
+		let secp = self.secp.as_ref().ok_or(Error::BrokenAggSigContext)?;
+
 		let mut retsig = AggSigPartialSignature::from(ffi::AggSigPartialSignature::new());
 		let retval = unsafe {
 			ffi::secp256k1_aggsig_partial_sign(
-				self.ctx,
+				secp.ctx,
 				self.aggsig_ctx,
 				retsig.as_mut_ptr(),
 				msg.as_ptr(),
@@ -355,70 +493,100 @@ impl AggSigContext {
 				index,
 			)
 		};
-		if retval == 0 {
+		if retval != 1 {
+			/* Even error might be recoverable, but it is not part of supported workflow. Treat as non recoverable is acceptable */
+			self.secp = None;
+			self.destroy_aggsig_ctx();
 			return Err(Error::PartialSigFailure);
 		}
 		Ok(retsig)
 	}
 
 	/// Aggregate multiple signature parts into a single aggregated signature
-	/// Returns: Ok(Signature) on success
+	/// Returns: Ok(AggSigSignature) on success
 	/// In:
 	/// partial_sigs: vector of partial signatures
+	/// Note, it is a caller responsibility to validate that every signer slot completed the
+	/// 			required `generate_nonce` and `partial_sign` steps.
+	/// Note, any non-success causes the wrapper to mark the context broken and destroy `aggsig_ctx`
+	///      It is acceptable for our usage, even  one attacker-controlled bad partial signature a
+	/// 	 permanent local denial of service for the signing round instead of a recoverable error.
 	pub fn combine_signatures(
-		&self,
+		&mut self,
 		partial_sigs: &Vec<AggSigPartialSignature>,
-	) -> Result<Signature, Error> {
-		let mut retsig = Signature::from(ffi::Signature::new());
-		let partial_sigs: Vec<*const ffi::AggSigPartialSignature> =
-			partial_sigs.into_iter().map(|p| p.as_ptr()).collect();
-		let partial_sigs = &partial_sigs[..];
+	) -> Result<AggSigSignature, Error> {
+		if partial_sigs.len() != self.pubkeys.len() {
+			return Err(Error::PartialSigFailure)
+		}
+
+		let mut retsig = AggSigSignature::new();
+		let mut ffi_sigs: Vec<ffi::AggSigPartialSignature> = Vec::with_capacity(partial_sigs.len());
+		for sig in partial_sigs {
+			ffi_sigs.push(sig.as_ffi());
+		}
+		let secp = self.secp.as_ref().ok_or(Error::BrokenAggSigContext)?;
+
 		let retval = unsafe {
 			ffi::secp256k1_aggsig_combine_signatures(
-				self.ctx,
+				secp.ctx,
 				self.aggsig_ctx,
 				retsig.as_mut_ptr(),
-				partial_sigs[0],
-				partial_sigs.len(),
+				ffi_sigs.as_ptr(),
+				ffi_sigs.len(),
 			)
 		};
-		if retval == 0 {
+		if retval != 1 {
+			self.secp = None;
+			self.destroy_aggsig_ctx();
 			return Err(Error::PartialSigFailure);
 		}
 		Ok(retsig)
 	}
 
-	/// Verifies aggregate sig
+	/// Verifies aggregate sig against the participant set used to create this context.
 	/// Returns: true if valid, okay if not
 	/// In:
 	/// msg: message to verify
 	/// sig: combined signature
-	/// pks: public keys
-	pub fn verify(&self, sig: Signature, msg: Message, pks: &Vec<PublicKey>) -> bool {
-		let pks: Vec<*const ffi::PublicKey> = pks.into_iter().map(|p| p.as_ptr()).collect();
-		let pks = &pks[..];
+	/// Note: internal verification failures such as scratch-space creation/use failure reported
+	///     as faled verification - false negative.  It is accepted, sinse memory starvation is fatal in any case.
+	pub fn verify(&self, sig: AggSigSignature, msg: Message) -> Result<bool,Error> {
+		let secp = self.secp.as_ref().ok_or(Error::BrokenAggSigContext)?;
+
+		if !sig.is_valid(&secp) {
+			return Ok(false);
+		}
+
+		let mut ffi_pks: Vec<ffi::PublicKey> = Vec::with_capacity(self.pubkeys.len());
+		for pk in &self.pubkeys {
+			ffi_pks.push(pk.as_ffi());
+		}
+
 		let retval = unsafe {
 			ffi::secp256k1_aggsig_build_scratch_and_verify(
-				self.ctx,
+				secp.ctx,
 				sig.as_ptr(),
 				msg.as_ptr(),
-				pks[0],
-				pks.len(),
+				ffi_pks.as_ptr(),
+				ffi_pks.len(),
 			)
 		};
-		match retval {
-			0 => false,
-			1 => true,
-			_ => false,
+		Ok(retval == 1)
+	}
+
+	fn destroy_aggsig_ctx(&mut self) {
+		if !self.aggsig_ctx.is_null() {
+			unsafe {
+				ffi::secp256k1_aggsig_context_destroy(self.aggsig_ctx);
+			}
+			self.aggsig_ctx = ptr::null_mut();
 		}
 	}
 }
 
 impl Drop for AggSigContext {
 	fn drop(&mut self) {
-		unsafe {
-			ffi::secp256k1_aggsig_context_destroy(self.aggsig_ctx);
-		}
+		self.destroy_aggsig_ctx();
 	}
 }
 
@@ -429,19 +597,24 @@ mod tests {
 		AggSigContext, Secp256k1,
 	};
 	use crate::aggsig::subtract_partial_signature;
-use crate::ffi;
+	use crate::constants;
+	use crate::ffi;
 	use crate::key::{PublicKey, SecretKey};
-	use rand::{thread_rng, Rng};
+	use rand::TryRng;
+	use rand::rngs::SysRng;
 	use crate::ContextFlag;
-	use crate::{AggSigPartialSignature, Message, Signature};
+	use crate::{AggSigPartialSignature, AggSigSignature, Message};
 
 	#[test]
 	fn test_aggsig_multisig() {
+		test_aggsig_multisig_impl(Secp256k1::with_caps(ContextFlag::SignOnly).unwrap()).unwrap();
+	}
+
+	fn test_aggsig_multisig_impl(secp: Secp256k1) -> Result<(), crate::Error> {
 		let numkeys = 5;
-		let secp = Secp256k1::with_caps(ContextFlag::Full);
 		let mut keypairs: Vec<(SecretKey, PublicKey)> = vec![];
 		for _ in 0..numkeys {
-			keypairs.push(secp.generate_keypair(&mut thread_rng()).unwrap());
+			keypairs.push(secp.generate_keypair(&mut SysRng)?);
 		}
 		let pks: Vec<PublicKey> = keypairs.clone().into_iter().map(|(_, p)| p).collect();
 		println!(
@@ -449,16 +622,18 @@ use crate::ffi;
 			pks.len(),
 			pks
 		);
-		let aggsig = AggSigContext::new(&secp, &pks);
+		let mut aggsig = AggSigContext::new(&pks)?;
 		println!("Generating nonces for each index");
 		for i in 0..numkeys {
-			let retval = aggsig.generate_nonce(i);
+			let retval = aggsig.generate_nonce(i).unwrap();
 			println!("{} returned {}", i, retval);
 			assert!(retval == true);
 		}
 
+		assert!(aggsig.generate_nonce(1000).is_err());
+
 		let mut msg = [0u8; 32];
-		thread_rng().fill(&mut msg);
+		SysRng.try_fill_bytes(&mut msg).unwrap();
 		let msg = Message::from_slice(&msg).unwrap();
 		let mut partial_sigs: Vec<AggSigPartialSignature> = vec![];
 		for i in 0..numkeys {
@@ -491,14 +666,17 @@ use crate::ffi;
 			"Verifying Combined sig: {:?}, msg: {:?}, pks:{:?}",
 			combined_sig, msg, pks
 		);
-		let result = aggsig.verify(combined_sig, msg, &pks);
+		let result = aggsig.verify(combined_sig, msg).unwrap();
 		println!("Signature verification: {}", result);
+		assert!(result);
+
+		Ok(())
 	}
 
 	#[test]
 	fn test_aggsig_single() {
-		let secp = Secp256k1::with_caps(ContextFlag::Full);
-		let (sk, pk) = secp.generate_keypair(&mut thread_rng()).unwrap();
+		let secp = Secp256k1::with_caps(ContextFlag::Full).unwrap();
+		let (sk, pk) = secp.generate_keypair(&mut SysRng).unwrap();
 
 		println!(
 			"Performing aggsig single context with seckey, pubkey: {:?},{:?}",
@@ -506,56 +684,56 @@ use crate::ffi;
 		);
 
 		let mut msg = [0u8; 32];
-		thread_rng().fill(&mut msg);
+		SysRng.try_fill_bytes(&mut msg).unwrap();
 		let msg = Message::from_slice(&msg).unwrap();
-		let sig = sign_single(&secp, &msg, &sk, None, None, None, None, None).unwrap();
+		let sig = sign_single(&secp, &msg, &sk, None, None, None, &pk, None).unwrap();
 
 		println!(
 			"Verifying aggsig single: {:?}, msg: {:?}, pk:{:?}",
 			sig, msg, pk
 		);
-		let result = verify_single(&secp, &sig, &msg, None, &pk, None, None, false);
+		let result = verify_single(&secp, &sig, &msg, None, &pk, &pk, None, false).unwrap();
 		println!("Signature verification single (correct): {}", result);
 		assert!(result == true);
 
 		let mut msg = [0u8; 32];
-		thread_rng().fill(&mut msg);
+		SysRng.try_fill_bytes(&mut msg).unwrap();
 		let msg = Message::from_slice(&msg).unwrap();
 		println!(
 			"Verifying aggsig single: {:?}, msg: {:?}, pk:{:?}",
 			sig, msg, pk
 		);
-		let result = verify_single(&secp, &sig, &msg, None, &pk, None, None, false);
+		let result = verify_single(&secp, &sig, &msg, None, &pk, &pk, None, false).unwrap();
 		println!("Signature verification single (wrong message): {}", result);
 		assert!(result == false);
 
 		// test optional extra key
 		let mut msg = [0u8; 32];
-		thread_rng().fill(&mut msg);
+		SysRng.try_fill_bytes(&mut msg).unwrap();
 		let msg = Message::from_slice(&msg).unwrap();
-		let (sk_extra, pk_extra) = secp.generate_keypair(&mut thread_rng()).unwrap();
-		let sig = sign_single(&secp, &msg, &sk, None, Some(&sk_extra), None, None, None).unwrap();
-		let result = verify_single(&secp, &sig, &msg, None, &pk, None, Some(&pk_extra), false);
+		let (sk_extra, pk_extra) = secp.generate_keypair(&mut SysRng).unwrap();
+		let sig = sign_single(&secp, &msg, &sk, None, Some(&sk_extra), None, &pk, None).unwrap();
+		let result = verify_single(&secp, &sig, &msg, None, &pk, &pk, Some(&pk_extra), false).unwrap();
 		assert!(result == true);
 	}
 
 	#[test]
 	fn test_aggsig_batch() {
-		let secp = Secp256k1::with_caps(ContextFlag::Full);
+		let secp = Secp256k1::with_caps(ContextFlag::Full).unwrap();
 
-		let mut sigs: Vec<Signature> = vec![];
+		let mut sigs: Vec<AggSigSignature> = vec![];
 		let mut msgs: Vec<Message> = vec![];
 		let mut pub_keys: Vec<PublicKey> = vec![];
 
 		for _ in 0..100 {
-			let (sk, pk) = secp.generate_keypair(&mut thread_rng()).unwrap();
+			let (sk, pk) = secp.generate_keypair(&mut SysRng).unwrap();
 			let mut msg = [0u8; 32];
-			thread_rng().fill(&mut msg);
+			SysRng.try_fill_bytes(&mut msg).unwrap();
 
 			let msg = Message::from_slice(&msg).unwrap();
-			let sig = sign_single(&secp, &msg, &sk, None, None, None, Some(&pk), None).unwrap();
+			let sig = sign_single(&secp, &msg, &sk, None, None, None, &pk, None).unwrap();
 
-			let result_single = verify_single(&secp, &sig, &msg, None, &pk, Some(&pk), None, false);
+			let result_single = verify_single(&secp, &sig, &msg, None, &pk, &pk, None, false).unwrap();
 			assert!(result_single == true);
 
 			pub_keys.push(pk);
@@ -564,14 +742,107 @@ use crate::ffi;
 		}
 
 		println!("Verifying aggsig batch of 100");
-		let result = verify_batch(&secp, &sigs, &msgs, &pub_keys);
+		let result = verify_batch(&secp, &sigs, &msgs, &pub_keys).unwrap();
 		assert!(result == true);
+
+		// Checking capabilities
+		let secp_none = Secp256k1::with_caps(ContextFlag::None).unwrap();
+		let secp_sign_only = Secp256k1::with_caps(ContextFlag::SignOnly).unwrap();
+		let secp_verify_only = Secp256k1::with_caps(ContextFlag::VerifyOnly).unwrap();
+		let secp_full = Secp256k1::with_caps(ContextFlag::Full).unwrap();
+		let secp_commit = Secp256k1::with_caps(ContextFlag::Commit).unwrap();
+
+		assert!(verify_batch(&secp_none, &sigs, &msgs, &pub_keys).is_err());
+		assert!(verify_batch(&secp_sign_only, &sigs, &msgs, &pub_keys).is_err());
+		assert!(verify_batch(&secp_verify_only, &sigs, &msgs, &pub_keys).is_ok());
+		assert!(verify_batch(&secp_full, &sigs, &msgs, &pub_keys).is_ok());
+		assert!(verify_batch(&secp_commit, &sigs, &msgs, &pub_keys).is_ok());
+
+	}
+
+	#[test]
+	fn test_aggsig_signature_validation() {
+		let secp_sign = Secp256k1::with_caps(ContextFlag::SignOnly).unwrap();
+		let secp_verify = Secp256k1::with_caps(ContextFlag::VerifyOnly).unwrap();
+		let zero_sig = AggSigSignature::new();
+		let (sk, pk) = secp_sign.generate_keypair(&mut SysRng).unwrap();
+		let (_nonce_sk, nonce_pk) = secp_sign.generate_keypair(&mut SysRng).unwrap();
+		let msg = Message::from_slice(&[42u8; 32]).unwrap();
+		let valid_sig = sign_single(&secp_sign, &msg, &sk, None, None, None, &pk, None).unwrap();
+
+		assert!(!zero_sig.is_valid(&secp_verify));
+		assert_eq!(
+			verify_single(&secp_verify, &zero_sig, &msg, None, &pk, &pk, None, false).unwrap(),
+			false
+		);
+		assert_eq!(
+			add_signatures_single(&secp_sign, vec![&zero_sig], &nonce_pk),
+			Err(crate::Error::InvalidSignature)
+		);
+		assert_eq!(
+			subtract_partial_signature(&secp_sign, &zero_sig, &valid_sig),
+			Err(crate::Error::InvalidSignature)
+		);
+
+		let mut invalid_non_lift = [0u8; 64];
+		invalid_non_lift[63] = 1;
+		let mut found_invalid_rx = false;
+		for candidate in 1u16..=u16::MAX {
+			let mut compressed = [0u8; constants::COMPRESSED_PUBLIC_KEY_SIZE];
+			compressed[0] = 0x02;
+			compressed[31] = (candidate >> 8) as u8;
+			compressed[32] = candidate as u8;
+			if PublicKey::from_slice(&secp_verify, &compressed).is_err() {
+				invalid_non_lift[30] = (candidate >> 8) as u8;
+				invalid_non_lift[31] = candidate as u8;
+				found_invalid_rx = true;
+				break;
+			}
+		}
+		assert!(found_invalid_rx);
+		let invalid_non_lift_sig = AggSigSignature {
+			0: ffi::Signature(invalid_non_lift),
+		};
+
+		assert!(!invalid_non_lift_sig.is_valid(&secp_verify));
+		assert_eq!(
+			verify_single(&secp_verify, &invalid_non_lift_sig, &msg, None, &pk, &pk, None, false).unwrap(),
+			false
+		);
+		assert_eq!(
+			add_signatures_single(&secp_sign, vec![&invalid_non_lift_sig], &nonce_pk),
+			Err(crate::Error::InvalidSignature)
+		);
+		assert_eq!(
+			subtract_partial_signature(&secp_sign, &invalid_non_lift_sig, &valid_sig),
+			Err(crate::Error::InvalidSignature)
+		);
+	}
+
+	#[test]
+	fn test_aggsig_from_compact() {
+		let secp = Secp256k1::with_caps(ContextFlag::Full).unwrap();
+		let (sk, pk) = secp.generate_keypair(&mut SysRng).unwrap();
+		let msg = Message::from_slice(&[7u8; 32]).unwrap();
+		let sig = sign_single(&secp, &msg, &sk, None, None, None, &pk, None).unwrap();
+
+		let compact = sig.serialize_compact(&secp).unwrap();
+		assert_ne!(&compact[..], sig.as_ref());
+
+		let parsed = AggSigSignature::from_compact(&secp, &compact).unwrap();
+		assert_eq!(parsed, sig);
+		assert!(parsed.is_valid(&secp));
+		assert_eq!(
+			verify_single(&secp, &parsed, &msg, None, &pk, &pk, None, false).unwrap(),
+			true
+		);
+		assert_eq!(*parsed.as_ref(), *sig.as_ref());
 	}
 
 	#[test]
 	fn test_aggsig_fuzz() {
-		let secp = Secp256k1::with_caps(ContextFlag::Full);
-		let (sk, pk) = secp.generate_keypair(&mut thread_rng()).unwrap();
+		let secp = Secp256k1::with_caps(ContextFlag::Full).unwrap();
+		let (sk, pk) = secp.generate_keypair(&mut SysRng).unwrap();
 
 		println!(
 			"Performing aggsig single context with seckey, pubkey: {:?},{:?}",
@@ -579,9 +850,9 @@ use crate::ffi;
 		);
 
 		let mut msg = [0u8; 32];
-		thread_rng().fill(&mut msg);
+		SysRng.try_fill_bytes(&mut msg).unwrap();
 		let msg = Message::from_slice(&msg).unwrap();
-		let sig = sign_single(&secp, &msg, &sk, None, None, None, None, None).unwrap();
+		let sig = sign_single(&secp, &msg, &sk, None, None, None, &pk, None).unwrap();
 
 		// force sig[32..] as 0 to simulate Fuzz test
 		let corrupted = &mut [0u8; 64];
@@ -590,14 +861,14 @@ use crate::ffi;
 			*elem = sig.0[i];
 			i += 1;
 		}
-		let corrupted_sig: Signature = Signature {
+		let corrupted_sig: AggSigSignature = AggSigSignature {
 			0: ffi::Signature(*corrupted),
 		};
 		println!(
 			"Verifying aggsig single: {:?}, msg: {:?}, pk:{:?}",
 			corrupted_sig, msg, pk
 		);
-		let result = verify_single(&secp, &corrupted_sig, &msg, None, &pk, None, None, false);
+		let result = verify_single(&secp, &corrupted_sig, &msg, None, &pk, &pk, None, false).unwrap();
 		println!("Signature verification single (correct): {}", result);
 		assert!(result == false);
 
@@ -608,28 +879,28 @@ use crate::ffi;
 			*elem = sig.0[i];
 			i += 1;
 		}
-		let corrupted_sig: Signature = Signature {
+		let corrupted_sig: AggSigSignature = AggSigSignature {
 			0: ffi::Signature(*corrupted),
 		};
 		println!(
 			"Verifying aggsig single: {:?}, msg: {:?}, pk:{:?}",
 			corrupted_sig, msg, pk
 		);
-		let result = verify_single(&secp, &corrupted_sig, &msg, None, &pk, None, None, false);
+		let result = verify_single(&secp, &corrupted_sig, &msg, None, &pk, &pk, None, false).unwrap();
 		println!("Signature verification single (correct): {}", result);
 		assert!(result == false);
 
 		// force pk as 0 to simulate Fuzz test
-		let zero_pk = PublicKey::new();
+		let zero_pk = PublicKey::blank();
 		println!(
 			"Verifying aggsig single: {:?}, msg: {:?}, pk:{:?}",
 			sig, msg, zero_pk
 		);
-		let result = verify_single(&secp, &sig, &msg, None, &zero_pk, None, None, false);
+		let result = verify_single(&secp, &sig, &msg, None, &zero_pk, &pk, None, false).unwrap();
 		println!("Signature verification single (correct): {}", result);
 		assert!(result == false);
 
-		let mut sigs: Vec<Signature> = vec![];
+		let mut sigs: Vec<AggSigSignature> = vec![];
 		sigs.push(sig);
 		let mut msgs: Vec<Message> = vec![];
 		msgs.push(msg);
@@ -639,7 +910,7 @@ use crate::ffi;
 			"Verifying aggsig batch: {:?}, msg: {:?}, pk:{:?}",
 			sig, msg, zero_pk
 		);
-		let result = verify_batch(&secp, &sigs, &msgs, &pub_keys);
+		let result = verify_batch(&secp, &sigs, &msgs, &pub_keys).unwrap();
 		println!("Signature verification batch: {}", result);
 		assert!(result == false);
 
@@ -658,26 +929,27 @@ use crate::ffi;
 			"Verifying aggsig single: {:?}, msg: {:?}, pk:{:?}",
 			sig, msg, corrupted_pk
 		);
-		let result = verify_single(&secp, &sig, &msg, None, &corrupted_pk, None, None, false);
+		let result = verify_single(&secp, &sig, &msg, None, &corrupted_pk, &pk, None, false).unwrap();
 		println!("Signature verification single (correct): {}", result);
 		assert!(result == false);
 
 		// more tests on other parameters
-		let zero_pk = PublicKey::new();
+		let zero_pk = PublicKey::blank();
 		let result = verify_single(
 			&secp,
 			&sig,
 			&msg,
 			Some(&zero_pk),
 			&zero_pk,
-			Some(&zero_pk),
+			&zero_pk,
 			Some(&zero_pk),
 			false,
-		);
+		)
+		.unwrap();
 		assert!(result == false);
 
 		let mut msg = [0u8; 32];
-		thread_rng().fill(&mut msg);
+		SysRng.try_fill_bytes(&mut msg).unwrap();
 		let msg = Message::from_slice(&msg).unwrap();
 		if sign_single(
 			&secp,
@@ -686,8 +958,8 @@ use crate::ffi;
 			None,
 			None,
 			Some(&zero_pk),
-			Some(&zero_pk),
-			Some(&zero_pk),
+			&zero_pk,
+			None,
 		).is_ok()
 		{
 			panic!("sign_single should fail on zero public key, but not!");
@@ -695,12 +967,66 @@ use crate::ffi;
 	}
 
 	#[test]
+	fn test_secp_cap() {
+		let secp_none = Secp256k1::with_caps(ContextFlag::None).unwrap();
+		let secp_sign_only = Secp256k1::with_caps(ContextFlag::SignOnly).unwrap();
+		let secp_verify_only = Secp256k1::with_caps(ContextFlag::VerifyOnly).unwrap();
+		let secp_full = Secp256k1::with_caps(ContextFlag::Full).unwrap();
+		let secp_commit = Secp256k1::with_caps(ContextFlag::Commit).unwrap();
+
+		assert!(export_secnonce_single(&secp_none).is_err());
+		assert!(export_secnonce_single(&secp_sign_only).is_ok());
+		assert!(export_secnonce_single(&secp_verify_only).is_err());
+		assert!(export_secnonce_single(&secp_full).is_ok());
+		assert!(export_secnonce_single(&secp_commit).is_ok());
+
+		let mut msg = [0u8; 32];
+		SysRng.try_fill_bytes(&mut msg).unwrap();
+		let msg = Message::from_slice(&msg).unwrap();
+
+		let (sk1, _pk1) = secp_full.generate_keypair(&mut SysRng).unwrap();
+		let (_sk2, pk2) = secp_full.generate_keypair(&mut SysRng).unwrap();
+
+		let secnonce_1 = export_secnonce_single(&secp_full).unwrap();
+		let secnonce_2 = export_secnonce_single(&secp_full).unwrap();
+
+		let _ = PublicKey::from_secret_key(&secp_full, &secnonce_1).unwrap();
+		let pubnonce_2 = PublicKey::from_secret_key(&secp_full, &secnonce_2).unwrap();
+
+		let mut nonce_sum = pubnonce_2.clone();
+		let _ = nonce_sum.add_exp_assign(&secp_full, &secnonce_1);
+
+		let mut pk_sum = pk2.clone();
+		let _ = pk_sum.add_exp_assign(&secp_full, &sk1);
+
+		assert!(sign_single( &secp_none, &msg, &sk1, Some(&secnonce_1), None, Some(&nonce_sum), &pk_sum, Some(&nonce_sum) ).is_err());
+		assert!(sign_single( &secp_sign_only, &msg, &sk1, Some(&secnonce_1), None, Some(&nonce_sum), &pk_sum, Some(&nonce_sum) ).is_ok());
+		assert!(sign_single( &secp_verify_only, &msg, &sk1, Some(&secnonce_1), None, Some(&nonce_sum), &pk_sum, Some(&nonce_sum) ).is_err());
+		assert!(sign_single( &secp_full, &msg, &sk1, Some(&secnonce_1), None, Some(&nonce_sum), &pk_sum, Some(&nonce_sum) ).is_ok());
+		assert!(sign_single( &secp_commit, &msg, &sk1, Some(&secnonce_1), None, Some(&nonce_sum), &pk_sum, Some(&nonce_sum) ).is_ok());
+
+
+		let (sk, pk) = secp_full.generate_keypair(&mut SysRng).unwrap();
+		let mut msg = [0u8; 32];
+		SysRng.try_fill_bytes(&mut msg).unwrap();
+		let msg = Message::from_slice(&msg).unwrap();
+		let (sk_extra, pk_extra) = secp_full.generate_keypair(&mut SysRng).unwrap();
+		let sig = sign_single(&secp_full, &msg, &sk, None, Some(&sk_extra), None, &pk, None).unwrap();
+
+		assert!( verify_single(&secp_none, &sig, &msg, None, &pk, &pk, Some(&pk_extra), false).is_err());
+		assert!( verify_single(&secp_sign_only, &sig, &msg, None, &pk, &pk, Some(&pk_extra), false).is_err());
+		assert!( verify_single(&secp_verify_only, &sig, &msg, None, &pk, &pk, Some(&pk_extra), false).is_ok());
+		assert!( verify_single(&secp_full, &sig, &msg, None, &pk, &pk, Some(&pk_extra), false).is_ok());
+		assert!( verify_single(&secp_commit, &sig, &msg, None, &pk, &pk, Some(&pk_extra), false).is_ok());
+	}
+
+	#[test]
 	fn test_aggsig_exchange() {
 		for _ in 0..20 {
-			let secp = Secp256k1::with_caps(ContextFlag::Full);
+			let secp = Secp256k1::with_caps(ContextFlag::Full).unwrap();
 			// Generate keys for sender, receiver
-			let (sk1, pk1) = secp.generate_keypair(&mut thread_rng()).unwrap();
-			let (sk2, pk2) = secp.generate_keypair(&mut thread_rng()).unwrap();
+			let (sk1, pk1) = secp.generate_keypair(&mut SysRng).unwrap();
+			let (sk2, pk2) = secp.generate_keypair(&mut SysRng).unwrap();
 
 			// Generate nonces for sender, receiver
 			let secnonce_1 = export_secnonce_single(&secp).unwrap();
@@ -716,7 +1042,7 @@ use crate::ffi;
 
 			// Random message
 			let mut msg = [0u8; 32];
-			thread_rng().fill(&mut msg);
+			SysRng.try_fill_bytes(&mut msg).unwrap();
 			let msg = Message::from_slice(&msg).unwrap();
 
 			// Add public keys (for storing in e)
@@ -731,8 +1057,8 @@ use crate::ffi;
 				Some(&secnonce_1),
 				None,
 				Some(&nonce_sum),
-				Some(&pk_sum),
-				Some(&nonce_sum),
+				&pk_sum,
+				Some(&nonce_sum)
 			).unwrap();
 
 			// Sender verifies receivers sig
@@ -742,10 +1068,10 @@ use crate::ffi;
 				&msg,
 				Some(&nonce_sum),
 				&pk1,
-				Some(&pk_sum),
+				&pk_sum,
 				None,
 				true,
-			);
+			).unwrap();
 			assert!(result == true);
 
 			// Sender signs
@@ -756,8 +1082,8 @@ use crate::ffi;
 				Some(&secnonce_2),
 				None,
 				Some(&nonce_sum),
-				Some(&pk_sum),
-				Some(&nonce_sum),
+				&pk_sum,
+				Some(&nonce_sum)
 			).unwrap();
 
 			// Receiver verifies sender's sig
@@ -767,15 +1093,26 @@ use crate::ffi;
 				&msg,
 				Some(&nonce_sum),
 				&pk2,
-				Some(&pk_sum),
+				&pk_sum,
 				None,
 				true,
-			);
+			).unwrap();
 			assert!(result == true);
 
 			let sig_vec = vec![&sig1, &sig2];
 			// Receiver calculates final sig
-			let final_sig = add_signatures_single(&secp, sig_vec, &nonce_sum).unwrap();
+			let final_sig = add_signatures_single(&secp, sig_vec.clone(), &nonce_sum).unwrap();
+
+			let secp_none = Secp256k1::with_caps(ContextFlag::None).unwrap();
+			let secp_sign_only = Secp256k1::with_caps(ContextFlag::SignOnly).unwrap();
+			let secp_verify_only = Secp256k1::with_caps(ContextFlag::VerifyOnly).unwrap();
+			let secp_full = Secp256k1::with_caps(ContextFlag::Full).unwrap();
+			let secp_commit = Secp256k1::with_caps(ContextFlag::Commit).unwrap();
+			assert!(add_signatures_single(&secp_none, sig_vec.clone(), &nonce_sum).is_err());
+			assert!(add_signatures_single(&secp_sign_only, sig_vec.clone(), &nonce_sum).is_ok());
+			assert!(add_signatures_single(&secp_verify_only, sig_vec.clone(), &nonce_sum).is_err());
+			assert!(add_signatures_single(&secp_full, sig_vec.clone(), &nonce_sum).is_ok());
+			assert!(add_signatures_single(&secp_commit, sig_vec.clone(), &nonce_sum).is_ok());
 
 			// Verification of final sig:
 			let result = verify_single(
@@ -784,10 +1121,10 @@ use crate::ffi;
 				&msg,
 				None,
 				&pk_sum,
-				Some(&pk_sum),
+				&pk_sum,
 				None,
 				false,
-			);
+			).unwrap();
 			assert!(result == true);
 
 			// Subtract sig1 from final sig

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -54,15 +54,19 @@ pub const PEDERSEN_COMMITMENT_SIZE_INTERNAL: usize = 64;
 pub const SINGLE_BULLET_PROOF_SIZE: usize = 675;
 
 #[cfg(feature = "bullet-proof-sizing")]
-pub const MAX_PROOF_SIZE: usize = SINGLE_BULLET_PROOF_SIZE;
 /// The max size of a range proof
+pub const MAX_PROOF_SIZE: usize = SINGLE_BULLET_PROOF_SIZE;
+
 #[cfg(not(feature = "bullet-proof-sizing"))]
+/// The max size of a range proof
 pub const MAX_PROOF_SIZE: usize = 5134;
 
-/// The maximum size of a message embedded in a range proof
 #[cfg(not(feature = "bullet-proof-sizing"))]
+/// The maximum size of a message embedded in a range proof
 pub const PROOF_MSG_SIZE: usize = 2048;
+
 #[cfg(feature = "bullet-proof-sizing")]
+/// The maximum size of a message embedded in a range proof
 pub const PROOF_MSG_SIZE: usize = 2048;
 
 /// The maximum size of an optional message embedded in a bullet proof

--- a/src/ecdh.rs
+++ b/src/ecdh.rs
@@ -21,20 +21,30 @@ use std::ops;
 use super::Secp256k1;
 use crate::key::{SecretKey, PublicKey};
 use crate::ffi;
+use crate::Error;
 
 /// A tag used for recovering the public key from a compact signature
-#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct SharedSecret(ffi::SharedSecret);
 
 impl SharedSecret {
     /// Creates a new shared secret from a pubkey and secret key
+    /// Note, point is expected to be a valid public key. It is caller responsibility to construct it correctly
     #[inline]
-    pub fn new(secp: &Secp256k1, point: &PublicKey, scalar: &SecretKey) -> SharedSecret {
-        unsafe {
-            let mut ss = ffi::SharedSecret::blank();
-            let res = ffi::secp256k1_ecdh(secp.ctx, &mut ss, point.as_ptr(), scalar.as_ptr());
-            debug_assert_eq!(res, 1);
-            SharedSecret(ss)
+    pub fn new(secp: &Secp256k1, point: &PublicKey, scalar: &SecretKey) -> Result<SharedSecret, Error> {
+        if !point.is_valid(secp) {
+            return Err(Error::InvalidPublicKey)
+        }
+
+        let mut ss = ffi::SharedSecret::blank();
+        let res = unsafe {
+            ffi::secp256k1_ecdh(secp.ctx, ss.as_mut_ptr(), point.as_ptr(), scalar.as_ptr())
+        };
+
+        if res == 1 {
+            Ok(SharedSecret(ss))
+        }
+        else {
+            Err(Error::GenericError)
         }
     }
 
@@ -59,7 +69,7 @@ impl ops::Index<usize> for SharedSecret {
 
     #[inline]
     fn index(&self, index: usize) -> &u8 {
-        &self.0[index]
+        &self.0.as_bytes()[index]
     }
 }
 
@@ -68,7 +78,7 @@ impl ops::Index<ops::Range<usize>> for SharedSecret {
 
     #[inline]
     fn index(&self, index: ops::Range<usize>) -> &[u8] {
-        &self.0[index]
+        &self.0.as_bytes()[index]
     }
 }
 
@@ -77,7 +87,7 @@ impl ops::Index<ops::RangeFrom<usize>> for SharedSecret {
 
     #[inline]
     fn index(&self, index: ops::RangeFrom<usize>) -> &[u8] {
-        &self.0[index.start..]
+        &self.0.as_bytes()[index.start..]
     }
 }
 
@@ -86,33 +96,61 @@ impl ops::Index<ops::RangeFull> for SharedSecret {
 
     #[inline]
     fn index(&self, _: ops::RangeFull) -> &[u8] {
-        &self.0[..]
+        &self.0.as_bytes()[..]
+    }
+}
+
+impl ::core::fmt::Debug for SharedSecret {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        write!(f, "SharedSecret(len={}, ****)", self.0.as_bytes().len())
+    }
+}
+
+// constant-time equality implementation,
+impl ::core::cmp::PartialEq for SharedSecret {
+    fn eq(&self, other: &Self) -> bool {
+        let a = self.0.as_bytes();
+        let b = other.0.as_bytes();
+
+        let mut diff: u8 = 0;
+        for i in 0..a.len() {
+            diff |= a[i] ^ b[i];
+        }
+        diff == 0
+    }
+}
+
+impl ::core::cmp::Eq for SharedSecret {}
+
+impl Clone for SharedSecret {
+    fn clone(&self) -> Self {
+        SharedSecret(ffi::SharedSecret::from_bytes(*self.0.as_bytes()))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use rand::thread_rng;
+    use rand::rngs::SysRng;
     use super::SharedSecret;
     use super::super::Secp256k1;
 
     #[test]
     fn ecdh() {
-        let s = Secp256k1::with_caps(crate::ContextFlag::SignOnly);
-        let (sk1, pk1) = s.generate_keypair(&mut thread_rng()).unwrap();
-        let (sk2, pk2) = s.generate_keypair(&mut thread_rng()).unwrap();
+        let s = Secp256k1::with_caps(crate::ContextFlag::SignOnly).unwrap();
+        let (sk1, pk1) = s.generate_keypair(&mut SysRng).unwrap();
+        let (sk2, pk2) = s.generate_keypair(&mut SysRng).unwrap();
 
-        let sec1 = SharedSecret::new(&s, &pk1, &sk2);
-        let sec2 = SharedSecret::new(&s, &pk2, &sk1);
-        let sec_odd = SharedSecret::new(&s, &pk1, &sk1);
-        assert_eq!(sec1, sec2);
+        let sec1 = SharedSecret::new(&s, &pk1, &sk2).unwrap();
+        let sec2 = SharedSecret::new(&s, &pk2, &sk1).unwrap();
+        let sec_odd = SharedSecret::new(&s, &pk1, &sk1).unwrap();
+        assert!(sec1 == sec2);
         assert!(sec_odd != sec2);
     }
 }
 
 #[cfg(all(test, feature = "unstable"))]
 mod benches {
-    use rand::thread_rng;
+    use rand::rngs::SysRng;
     use test::{Bencher, black_box};
 
     use super::SharedSecret;
@@ -120,14 +158,13 @@ mod benches {
 
     #[bench]
     pub fn bench_ecdh(bh: &mut Bencher) {
-        let s = Secp256k1::with_caps(::ContextFlag::SignOnly);
-        let (sk, pk) = s.generate_keypair(&mut thread_rng()).unwrap();
+        let s = Secp256k1::with_caps(::ContextFlag::SignOnly).unwrap();
+        let (sk, pk) = s.generate_keypair(&mut SysRng).unwrap();
 
-        let s = Secp256k1::new();
+        let s = Secp256k1::new().unwrap();
         bh.iter( || {
             let res = SharedSecret::new(&s, &pk, &sk);
             black_box(res);
         });
     }
 }
-

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -16,7 +16,8 @@
 //! # FFI bindings
 //! Direct bindings to the underlying C library functions. These should
 //! not be needed for most users.
-use libc::{c_int, c_uchar, c_uint, c_void, size_t};
+use libc::{c_int, c_char, c_uchar, c_uint, c_void, size_t};
+use zeroize::Zeroize;
 
 /// Flag for context to enable no precomputation
 pub const SECP256K1_START_NONE: c_uint = (1 << 0) | 0;
@@ -40,8 +41,8 @@ pub type NonceFn = unsafe extern "C" fn(nonce32: *mut c_uchar,
                                         msg32: *const c_uchar,
                                         key32: *const c_uchar,
                                         algo16: *const c_uchar,
-                                        attempt: c_uint,
-                                        data: *const c_void);
+                                        data: *mut c_void,
+                                        counter: c_uint) -> c_int;
 
 
 /// A Secp256k1 context, containing various precomputed values and such
@@ -65,38 +66,52 @@ pub type NonceFn = unsafe extern "C" fn(nonce32: *mut c_uchar,
 #[repr(C)] pub struct BulletproofGenerators(c_int);
 
 /// Generator
-#[repr(C)] 
+#[repr(C)]
+#[derive(Clone)]
 pub struct Generator(pub [c_uchar; 64]);
 impl Copy for Generator {}
-impl_array_newtype!(Generator, c_uchar, 64);
-impl_raw_debug!(Generator);
+
+/// Library-internal representation of a Pedersen commitment.
+///
+/// This mirrors the opaque 64-byte C type and must only be constructed by
+/// FFI functions that initialize commitments.
+#[repr(C)]
+#[derive(Clone)]
+pub struct PedersenCommitment(pub [c_uchar; 64]);
+impl Copy for PedersenCommitment {}
+
+impl PedersenCommitment {
+    /// Create a new (zeroed) commitment usable for the FFI interface
+    pub fn blank() -> PedersenCommitment { PedersenCommitment([0; 64]) }
+}
 
 /// Library-internal representation of a Secp256k1 public key
 #[repr(C)]
-pub struct PublicKey(pub [c_uchar; 64]);
+pub struct PublicKey(pub(crate) [c_uchar; 64]);
 impl Copy for PublicKey {}
-impl_array_newtype!(PublicKey, c_uchar, 64);
+// Note: Raw data access for PublicKey is needed and expected. Even PublicKey os opaque type,
+//      sometimes we need an access to the raw data.
+impl_array_newtype!(PublicKey, c_uchar, 64, no_serde);
+// Note: It is expected that Debug will show raw data instead of canonical. It is acceptable for tests and logs.
 impl_raw_debug!(PublicKey);
 
 impl PublicKey {
-    /// Create a new (zeroed) public key usable for the FFI interface
-    pub fn new() -> PublicKey { PublicKey([0; 64]) }
-    /// Create a new (uninitialized) public key usable for the FFI interface
-    pub fn blank() -> PublicKey { PublicKey([0; 64]) }
+    /// Create a new zeroed public key buffer for internal FFI use.
+    pub(crate) fn blank() -> PublicKey { PublicKey([0; 64]) }
 }
 
 /// Library-internal representation of a Secp256k1 signature
 #[repr(C)]
 pub struct Signature(pub [c_uchar; 64]);
 impl Copy for Signature {}
-impl_array_newtype!(Signature, c_uchar, 64);
+impl_array_newtype!(Signature, c_uchar, 64, no_serde);
 impl_raw_debug!(Signature);
 
 /// Library-internal representation of a Secp256k1 signature + recovery ID
 #[repr(C)]
 pub struct RecoverableSignature([c_uchar; 65]);
 impl Copy for RecoverableSignature {}
-impl_array_newtype!(RecoverableSignature, c_uchar, 65);
+impl_array_newtype!(RecoverableSignature, c_uchar, 65, no_serde);
 impl_raw_debug!(RecoverableSignature);
 
 /// Library-internal representation of a Secp256k1 aggsig partial signature
@@ -109,17 +124,11 @@ impl_raw_debug!(AggSigPartialSignature);
 impl Signature {
     /// Create a new (zeroed) signature usable for the FFI interface
     pub fn new() -> Signature { Signature([0; 64]) }
-    /// Create a signature from raw data
-    pub fn from_data(data: [u8; 64]) -> Signature { Signature(data) }
-    /// Create a new (uninitialized) signature usable for the FFI interface
-    pub fn blank() -> Signature { Signature([0; 64]) }
 }
 
 impl RecoverableSignature {
     /// Create a new (zeroed) signature usable for the FFI interface
     pub fn new() -> RecoverableSignature { RecoverableSignature([0; 65]) }
-    /// Create a new (uninitialized) signature usable for the FFI interface
-    pub fn blank() -> RecoverableSignature { RecoverableSignature([0; 65]) }
 }
 
 impl AggSigPartialSignature {
@@ -132,15 +141,48 @@ impl AggSigPartialSignature {
 /// Library-internal representation of an ECDH shared secret
 #[repr(C)]
 pub struct SharedSecret([c_uchar; 32]);
-impl_array_newtype!(SharedSecret, c_uchar, 32);
-impl_raw_debug!(SharedSecret);
+// We can't have Debug implemented because it might print the data as a HEX - potential issue
 
 impl SharedSecret {
     /// Create a new (zeroed) signature usable for the FFI interface
     pub fn new() -> SharedSecret { SharedSecret([0; 32]) }
     /// Create a new (uninitialized) signature usable for the FFI interface
-    pub unsafe fn blank() -> SharedSecret { SharedSecret([0; 32]) }
+    pub fn blank() -> SharedSecret { SharedSecret([0; 32]) }
+
+    /// Build from the data
+    #[inline]
+    pub fn from_bytes(bytes: [c_uchar; 32]) -> SharedSecret {
+        SharedSecret(bytes)
+    }
+
+    /// Converts the object to a raw pointer for FFI interfacing
+    #[inline]
+    pub fn as_ptr(&self) -> *const c_uchar {
+        self.0.as_ptr()
+    }
+
+    /// Converts the object to a mutable raw pointer for FFI interfacing
+    #[inline]
+    pub fn as_mut_ptr(&mut self) -> *mut c_uchar {
+        self.0.as_mut_ptr()
+    }
+
+    /// Bytes for rust code
+    #[inline]
+    pub fn as_bytes(&self) -> &[c_uchar; 32] {
+        &self.0
+    }
 }
+
+impl Drop for SharedSecret {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+
+/// FFI Callback for PublicKey verification
+pub type CallbackFn = Option<unsafe extern "C" fn(message: *const c_char, data: *mut c_void)>;
 
 #[allow(missing_docs)]
 extern "C" {
@@ -151,7 +193,7 @@ extern "C" {
     // Contexts
     pub fn secp256k1_context_create(flags: c_uint) -> *mut Context;
 
-    pub fn secp256k1_context_clone(cx: *mut Context) -> *mut Context;
+    pub fn secp256k1_context_clone(cx: *const Context) -> *mut Context;
 
     pub fn secp256k1_context_destroy(cx: *mut Context);
 
@@ -159,7 +201,7 @@ extern "C" {
                                        seed32: *const c_uchar)
                                        -> c_int;
     // Scratch space
-    pub fn secp256k1_scratch_space_create(cx: *mut Context,
+    pub fn secp256k1_scratch_space_create(cx: *const Context,
                                           max_size: size_t)
                                           -> *mut ScratchSpace;
 
@@ -178,12 +220,23 @@ extern "C" {
     // one goal is to use Rust's type system to eliminate all possible
     // bad inputs.)
 
+    // Note, we still need secp256k1_context_set_illegal_callback in order to validate pub key
+    // with secp256k1_ec_pubkey_serialize. Since secp256k1_ec_pubkey_serialize allways return 1,
+    // the callback is the only way to validate.
+    // Note, thread safety comes from Context. It is illegal to use same Context instance in
+    // multiple threads
+    pub fn secp256k1_context_set_illegal_callback(
+        cx: *mut Context,
+        fun: CallbackFn,
+        data: *mut c_void,
+    );
+
     // Pubkeys
     pub fn secp256k1_ec_pubkey_parse(cx: *const Context, pk: *mut PublicKey,
                                      input: *const c_uchar, in_len: size_t)
                                      -> c_int;
 
-    pub fn secp256k1_ec_pubkey_serialize(cx: *const Context, output: *const c_uchar,
+    pub fn secp256k1_ec_pubkey_serialize(cx: *const Context, output: *mut c_uchar,
                                          out_len: *mut size_t, pk: *const PublicKey,
                                          compressed: c_uint)
                                          -> c_int;
@@ -201,11 +254,11 @@ extern "C" {
                                          input: *const c_uchar, in_len: size_t)
                                          -> c_int;
 
-    pub fn secp256k1_ecdsa_signature_serialize_der(cx: *const Context, output: *const c_uchar,
+    pub fn secp256k1_ecdsa_signature_serialize_der(cx: *const Context, output: *mut c_uchar,
                                                    out_len: *mut size_t, sig: *const Signature)
                                                    -> c_int;
 
-    pub fn secp256k1_ecdsa_signature_serialize_compact(cx: *const Context, output64: *const c_uchar,
+    pub fn secp256k1_ecdsa_signature_serialize_compact(cx: *const Context, output64: *mut c_uchar,
                                                        sig: *const Signature)
                                                        -> c_int;
 
@@ -213,7 +266,7 @@ extern "C" {
                                                                input64: *const c_uchar, recid: c_int)
                                                                -> c_int;
 
-    pub fn secp256k1_ecdsa_recoverable_signature_serialize_compact(cx: *const Context, output64: *const c_uchar,
+    pub fn secp256k1_ecdsa_recoverable_signature_serialize_compact(cx: *const Context, output64: *mut c_uchar,
                                                                    recid: *mut c_int, sig: *const RecoverableSignature)
                                                                    -> c_int;
 
@@ -308,18 +361,18 @@ extern "C" {
                                            -> c_int;
 
     pub fn secp256k1_aggsig_verify_single(cx: *const Context,
-                                          sig: *const Signature,
+                                          sig: *const c_uchar,
                                           msg32: *const c_uchar,
                                           pubnonce: *const PublicKey,
                                           pk: *const PublicKey,
                                           pk_total: *const PublicKey,
                                           extra_pubkey: *const PublicKey,
-                                          is_partial: c_uint)
+                                          is_partial: c_int)
                                            -> c_int;
 
     pub fn secp256k1_schnorrsig_verify_batch(cx: *const Context,
                                              scratch: *mut ScratchSpace,
-                                             sig: *const *const c_uchar,
+                                             sig: *const *const Signature,
                                              msg32: *const *const c_uchar,
                                              pk: *const *const PublicKey,
                                              n_sigs: size_t)
@@ -327,7 +380,7 @@ extern "C" {
 
     pub fn secp256k1_aggsig_add_signatures_single(cx: *const Context,
                                                   ret_sig: *mut Signature,
-                                                  sigs: *const *const c_uchar,
+                                                  sigs: *const *const Signature,
                                                   num_sigs: size_t,
                                                   pubnonce_total: *const PublicKey)
                                                       -> c_int;
@@ -372,7 +425,7 @@ extern "C" {
     pub fn secp256k1_ec_pubkey_combine(cx: *const Context,
                                        out: *mut PublicKey,
                                        ins: *const *const PublicKey,
-                                       n: c_int)
+                                       n: size_t)
                                        -> c_int;
 
     pub fn secp256k1_ec_privkey_tweak_inv(cx: *const Context,
@@ -384,21 +437,21 @@ extern "C" {
                                           -> c_int;
 
     pub fn secp256k1_ecdh(cx: *const Context,
-                          out: *mut SharedSecret,
+                          out: *mut c_uchar,
                           point: *const PublicKey,
                           scalar: *const c_uchar)
                           -> c_int;
 
   // Parse a 33-byte commitment into 64 byte internal commitment object
   pub fn secp256k1_pedersen_commitment_parse(cx: *const Context,
-                                              commit: *mut c_uchar,
+                                              commit: *mut PedersenCommitment,
                                               input: *const c_uchar)
                                               -> c_int;
 
   // Serialize a 64-byte commit object into a 33 byte serialized byte sequence
   pub fn secp256k1_pedersen_commitment_serialize(cx: *const Context,
                                                   output: *mut c_uchar,
-                                                  commit: *const c_uchar)
+                                                  commit: *const PedersenCommitment)
                                                   -> c_int;
 
 
@@ -406,32 +459,32 @@ extern "C" {
 	// The commitment is 33 bytes, the blinding factor is 32 bytes.
 	pub fn secp256k1_pedersen_commit(
 		ctx: *const Context,
-		commit: *mut c_uchar,
+		commit: *mut PedersenCommitment,
 		blind: *const c_uchar,
 		value: u64,
-		value_gen: *const c_uchar,
-		blind_gen: *const c_uchar
+		value_gen: *const Generator,
+		blind_gen: *const Generator
 	) -> c_int;
 
 	// Generates a pedersen commitment: *commit = blind * G + value * G2.
 	// The commitment is 33 bytes, the blinding factor and the value are 32 bytes.
 	pub fn secp256k1_pedersen_blind_commit(
 		ctx: *const Context,
-		commit: *mut c_uchar,
+		commit: *mut PedersenCommitment,
 		blind: *const c_uchar,
 		value: *const c_uchar,
-		value_gen: *const c_uchar,
-		blind_gen: *const c_uchar
+		value_gen: *const Generator,
+		blind_gen: *const Generator
 	) -> c_int;
 
 	// Get the public key of a pedersen commitment
 	pub fn secp256k1_pedersen_commitment_to_pubkey(
 	    cx: *const Context, pk: *mut PublicKey,
-	    commit: *const c_uchar) -> c_int;
+	    commit: *const PedersenCommitment) -> c_int;
 
 	// Get a pedersen commitment from a pubkey
 	pub fn secp256k1_pubkey_to_pedersen_commitment(
-	    cx: *const Context, commit: *mut c_uchar,
+	    cx: *const Context, commit: *mut PedersenCommitment,
 	    pk: *const PublicKey) -> c_int;
 
 	// Takes a list of n pointers to 32 byte blinding values, the first negs
@@ -439,7 +492,7 @@ extern "C" {
 	// calculates an additional blinding value that adds to zero.
 	pub fn secp256k1_pedersen_blind_sum(
 		ctx: *const Context,
-		blind_out: *const c_uchar,
+		blind_out: *mut c_uchar,
 		blinds: *const *const c_uchar,
 		n: size_t,
 		npositive: size_t
@@ -449,10 +502,10 @@ extern "C" {
 	// the second and returns the resulting commitment.
 	pub fn secp256k1_pedersen_commit_sum(
 		ctx: *const Context,
-		commit_out: *const c_uchar,
-		commits: *const *const c_uchar,
+		commit_out: *mut PedersenCommitment,
+		commits: *const *const PedersenCommitment,
 		pcnt: size_t,
-		ncommits: *const *const c_uchar,
+		ncommits: *const *const PedersenCommitment,
 		ncnt: size_t
 	) -> c_int;
 
@@ -462,17 +515,17 @@ extern "C" {
         blind_switch: *mut c_uchar,
         blind: *const c_uchar,
         value: u64,
-        value_gen: *const c_uchar,
-        blind_gen: *const c_uchar,
-        switch_pubkey: *const c_uchar
+        value_gen: *const Generator,
+        blind_gen: *const Generator,
+        switch_pubkey: *const PublicKey
     ) -> c_int;
 
 	// Takes two list of 64-byte commitments and sums the first set and
 	// subtracts the second and verifies that they sum to 0.
 	pub fn secp256k1_pedersen_verify_tally(ctx: *const Context,
-		commits: *const *const c_uchar,
+		commits: *const *const PedersenCommitment,
 		pcnt: size_t,
-		ncommits: *const *const c_uchar,
+		ncommits: *const *const PedersenCommitment,
 		ncnt: size_t
 	) -> c_int;
 
@@ -495,24 +548,24 @@ extern "C" {
 		nonce: *const c_uchar,
 		min_value: *mut u64,
 		max_value: *mut u64,
-		commit: *const c_uchar,
+		commit: *const PedersenCommitment,
 		proof: *const c_uchar,
 		plen: size_t,
 		extra_commit: *const c_uchar,
 		extra_commit_len: size_t,
-		gen: *const c_uchar
+		gen: *const Generator
 	) -> c_int;
 
 	pub fn secp256k1_rangeproof_verify(
 		ctx: *const Context,
-		min_value: &mut u64,
-		max_value: &mut u64,
-		commit: *const c_uchar,
+		min_value: *mut u64,
+		max_value: *mut u64,
+		commit: *const PedersenCommitment,
 		proof: *const c_uchar,
 		plen: size_t,
 		extra_commit: *const c_uchar,
 		extra_commit_len: size_t,
-		gen: *const c_uchar
+		gen: *const Generator
 	) -> c_int;
 
 	pub fn secp256k1_rangeproof_sign(
@@ -520,7 +573,7 @@ extern "C" {
 		proof: *mut c_uchar,
 		plen: *mut size_t,
 		min_value: u64,
-		commit: *const c_uchar,
+		commit: *const PedersenCommitment,
 		blind: *const c_uchar,
 		nonce: *const c_uchar,
 		exp: c_int,
@@ -530,12 +583,12 @@ extern "C" {
 		msg_len: size_t,
 		extra_commit: *const c_uchar,
 		extra_commit_len: size_t,
-		gen: *const c_uchar
+		gen: *const Generator
 	) -> c_int;
 
 	pub fn secp256k1_bulletproof_generators_create(
 		ctx: *const Context,
-		blinding_gen: *const c_uchar,
+		blinding_gen: *const Generator,
 		n: size_t,
 	) -> *mut BulletproofGenerators;
 
@@ -556,9 +609,9 @@ extern "C" {
 		value: *const u64,
 		min_value: *const u64,
 		blind: *const *const c_uchar,
-		commits: *const *const c_uchar,
+		commits: *const *const PedersenCommitment,
 		n_commits: size_t,
-		value_gen: *const c_uchar,
+		value_gen: *const Generator,
 		nbits: size_t,
 		nonce: *const c_uchar,
 		private_nonce: *const c_uchar,
@@ -574,10 +627,10 @@ extern "C" {
 		proof: *const c_uchar,
 		plen: size_t,
 		min_value: *const u64,
-		commit: *const c_uchar,
+		commit: *const PedersenCommitment,
 		n_commits: size_t,
 		nbits: size_t,
-		value_gen: *const c_uchar,
+		value_gen: *const Generator,
 		extra_commit: *const c_uchar,
 		extra_commit_len: size_t
 	) -> c_int;
@@ -590,12 +643,12 @@ extern "C" {
 		n_proofs: size_t,
 		plen: size_t,
 		min_value: *const *const u64,
-		commits: *const *const c_uchar,
+		commits: *const *const PedersenCommitment,
 		n_commits: size_t,
 		nbits: size_t,
-		value_gen: *const c_uchar,
+		value_gen: *const Generator,
 		extra_commit: *const *const c_uchar,
-		extra_commit_len: *const size_t
+		extra_commit_len: *mut size_t
 	) -> c_int;
 
 	pub fn secp256k1_bulletproof_rangeproof_rewind(
@@ -604,10 +657,12 @@ extern "C" {
 		blind: *mut c_uchar,
 		proof: *const c_uchar,
 		plen: size_t,
-		min_value: u64,
-		commit: *const c_uchar,
-		value_gen: *const c_uchar,
+		min_value: *const u64,
+		commit: *const PedersenCommitment,
+		value_gen: *const Generator,
+		blind_gen: *const Generator,
 		nonce: *const c_uchar,
+        private_nonce: *const c_uchar,
 		extra_commit: *const c_uchar,
 		extra_commit_len: size_t,
 		message: *mut c_uchar,

--- a/src/key.rs
+++ b/src/key.rs
@@ -17,15 +17,19 @@
 
 use std::marker;
 use arrayvec::ArrayVec;
-use rand::Rng;
+use rand::TryCryptoRng;
 use serde::{Serialize, Deserialize, Serializer, Deserializer};
 
 use super::{Secp256k1, ContextFlag};
-use super::Error::{self, IncapableContext, InvalidPublicKey, InvalidSecretKey};
+use super::Error::{
+    self, GenericError, IncapableContext, InvalidPublicKey, InvalidSecretKey, ZeroSecretKey,
+};
 use crate::constants;
 use crate::ffi;
-
+use libc::{c_char, c_void};
+use std::ptr;
 use zeroize::Zeroize;
+use crate::constants::GENERATOR_PUB_J_RAW;
 
 /// Secret 256-bit key used as `x` in an ECDSA signature
 //#[derive(Zeroize)]
@@ -33,8 +37,7 @@ use zeroize::Zeroize;
 // Note, Zeroize on drop implemented manually. Zeroize crate didn't implement macros for
 // derive. Since derive(Zeroize) doesn;t work, we can do the same manually.
 pub struct SecretKey(pub [u8; constants::SECRET_KEY_SIZE]);
-impl_array_newtype!(SecretKey, u8, constants::SECRET_KEY_SIZE);
-impl_pretty_debug!(SecretKey);
+impl_array_newtype!(SecretKey, u8, constants::SECRET_KEY_SIZE, no_serde_no_comp);
 
 // If Zeroize will fix issue with the latest rust compiler, we can switch back
 // to derive
@@ -44,12 +47,11 @@ impl Drop for SecretKey {
     }
 }
 
-/// The number 1 encoded as a secret key
-/// Deprecated; `static` is not what I want; use `ONE_KEY` instead
-pub static ONE: SecretKey = SecretKey([0, 0, 0, 0, 0, 0, 0, 0,
-                                       0, 0, 0, 0, 0, 0, 0, 0,
-                                       0, 0, 0, 0, 0, 0, 0, 0,
-                                       0, 0, 0, 0, 0, 0, 0, 1]);
+impl ::core::fmt::Debug for SecretKey {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        write!(f, "SecretKey(len={}, ****)", self.0.len())
+    }
+}
 
 /// The number 0 encoded as a secret key
 pub const ZERO_KEY: SecretKey = SecretKey([0, 0, 0, 0, 0, 0, 0, 0,
@@ -65,26 +67,28 @@ pub const ONE_KEY: SecretKey = SecretKey([0, 0, 0, 0, 0, 0, 0, 0,
 
 /// A Secp256k1 public key, used for verification of signatures
 #[derive(Copy, Clone, PartialEq, Eq, Debug, PartialOrd, Ord, Hash)]
-pub struct PublicKey(pub ffi::PublicKey);
+pub struct PublicKey(pub(crate) ffi::PublicKey);
 
 
-fn random_32_bytes<R: Rng>(rng: &mut R) -> [u8; 32] {
+fn random_32_bytes<R: TryCryptoRng>(rng: &mut R) -> Result<[u8; 32], Error> {
     let mut ret = [0u8; 32];
-    rng.fill(&mut ret);
-    ret
+    rng.try_fill_bytes(&mut ret)
+        .map_err(|_| Error::SysRngFailure)?;
+    Ok(ret)
 }
 
 impl SecretKey {
     /// Creates a new random secret key
     #[inline]
-    pub fn new<R: Rng>(secp: &Secp256k1, rng: &mut R) -> SecretKey {
-        let mut data = random_32_bytes(rng);
-        unsafe {
-            while ffi::secp256k1_ec_seckey_verify(secp.ctx, data.as_ptr()) == 0 {
-                data = random_32_bytes(rng);
+    pub fn new<R: TryCryptoRng>(secp: &Secp256k1, rng: &mut R) -> Result<SecretKey, Error> {
+        let mut data = random_32_bytes(rng)?;
+        let secret = loop {
+            if let Ok(secret) = SecretKey::from_slice(secp, &data) {
+                break secret;
             }
-        }
-        SecretKey(data)
+            data = random_32_bytes(rng)?;
+        };
+        Ok(secret)
     }
 
     /// Converts a `SECRET_KEY_SIZE`-byte slice to a secret key
@@ -93,12 +97,19 @@ impl SecretKey {
                         -> Result<SecretKey, Error> {
         match data.len() {
             constants::SECRET_KEY_SIZE => {
-                let mut ret = [0; constants::SECRET_KEY_SIZE];
                 unsafe {
-                    if ffi::secp256k1_ec_seckey_verify(secp.ctx, data.as_ptr()) == 0 {
+                    if ffi::secp256k1_ec_seckey_verify(secp.ctx, data.as_ptr()) != 1 {
+                        let mut nonzero = 0u8;
+                        for byte in data {
+                            nonzero |= *byte;
+                        }
+                        if nonzero == 0 {
+                            return Err(ZeroSecretKey);
+                        }
                         return Err(InvalidSecretKey);
                     }
                 }
+                let mut ret = [0; constants::SECRET_KEY_SIZE];
                 ret[..].copy_from_slice(data);
                 Ok(SecretKey(ret))
             }
@@ -108,6 +119,7 @@ impl SecretKey {
 
     #[inline]
     /// Adds one secret key to another, modulo the curve order
+    /// Note, in case of failure, this SecretKey data can be invalid.
     pub fn add_assign(&mut self, secp: &Secp256k1, other: &SecretKey)
                      -> Result<(), Error> {
         unsafe {
@@ -121,6 +133,7 @@ impl SecretKey {
 
     #[inline]
     /// Multiplies one secret key by another, modulo the curve order
+    /// Note, in case of failure, this SecretKey data can be invalid.
     pub fn mul_assign(&mut self, secp: &Secp256k1, other: &SecretKey)
                      -> Result<(), Error> {
         unsafe {
@@ -133,7 +146,8 @@ impl SecretKey {
     }
 
     #[inline]
-    /// Inverses the secret key
+    /// Inverts the secret key.
+    /// Note, in case of failure, this SecretKey data can be invalid.
     pub fn inv_assign(&mut self, secp: &Secp256k1)
                      -> Result<(), Error> {
         unsafe {
@@ -147,6 +161,7 @@ impl SecretKey {
 
     #[inline]
     /// Negates the secret key
+    /// Note, in case of failure, this SecretKey data can be invalid.
     pub fn neg_assign(&mut self, secp: &Secp256k1)
                      -> Result<(), Error> {
         unsafe {
@@ -159,26 +174,122 @@ impl SecretKey {
     }
 }
 
+// constant-time equality implementation,
+impl ::core::cmp::PartialEq for SecretKey {
+    fn eq(&self, other: &Self) -> bool {
+        let a = &self.0;
+        let b = &other.0;
+
+        let mut diff: u8 = 0;
+        for i in 0..a.len() {
+            diff |= a[i] ^ b[i];
+        }
+        diff == 0
+    }
+}
+
+impl ::core::cmp::Eq for SecretKey {}
+
+
+// Note, SecretKey deserialized as a row data. It is caller responsibility to encrypt it and never store it as it is.
+// Sinse normally all the wallet data is stored into ensrypted storage - that shouldn't be a problem
+impl<'de> Deserialize<'de> for SecretKey {
+    fn deserialize<D>(d: D) -> Result<SecretKey, D::Error>
+    where D: Deserializer<'de>
+    {
+        use serde::de;
+        struct Visitor {
+            marker: marker::PhantomData<PublicKey>,
+        }
+        impl<'de> de::Visitor<'de> for Visitor {
+            type Value = SecretKey;
+
+            #[inline]
+            fn visit_seq<A>(self, mut a: A) -> Result<SecretKey, A::Error>
+            where A: de::SeqAccess<'de>
+            {
+                let mut ret: [u8; constants::SECRET_KEY_SIZE] = [0u8; constants::SECRET_KEY_SIZE];
+
+                for i in 0..constants::SECRET_KEY_SIZE {
+                    ret[i] = match a.next_element()? {
+                        Some(c) => c,
+                        None => return Err(::serde::de::Error::invalid_length(i, &self)),
+                    };
+                }
+
+                let one_after_last: Option<u8> = a.next_element()?;
+                if one_after_last.is_some() {
+                    return Err(::serde::de::Error::invalid_length(constants::SECRET_KEY_SIZE + 1, &self));
+                }
+
+                let s = Secp256k1::without_caps()
+                    .map_err( |e| ::serde::de::Error::custom(format!("Secp256k1 creation error, {}", e)) )?;
+                let ret = SecretKey::from_slice(&s, &ret)
+                    .map_err( |e| ::serde::de::Error::custom(format!("Secret key data is invalid, {}", e)) )?;
+
+                Ok(ret)
+            }
+
+            fn expecting(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                write!(f, "a sequence of {} bytes representing a valid secret key",
+                       constants::SECRET_KEY_SIZE)
+            }
+        }
+
+        // Begin actual function
+        d.deserialize_seq(Visitor { marker: ::std::marker::PhantomData })
+    }
+}
+
+impl Serialize for SecretKey {
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
+    where S: Serializer
+    {
+        (&self.0[..]).serialize(s)
+    }
+}
+
+
+
+unsafe extern "C" fn illegal_cb(_message: *const c_char, data: *mut c_void) {
+    let hit = &mut *(data as *mut bool);
+    *hit = true;
+}
 impl PublicKey {
-    /// Creates a new zeroed out public key
+    /// Creates a new zeroed public key buffer for internal FFI use.
     #[inline]
-    pub fn new() -> PublicKey {
-        PublicKey(ffi::PublicKey::new())
+    pub(crate) fn blank() -> PublicKey {
+        PublicKey(ffi::PublicKey::blank())
+    }
+
+    /// Public Key for J Generator
+    pub fn pub_j_raw() -> PublicKey {
+        PublicKey(ffi::PublicKey(GENERATOR_PUB_J_RAW))
     }
 
     /// Creates a new public key as the sum of the provided keys
     pub fn from_combination(secp: &Secp256k1, in_keys: Vec<&PublicKey>)
                          -> Result<PublicKey, Error> {
-        let mut retkey = PublicKey::new();
         if secp.caps == ContextFlag::SignOnly || secp.caps == ContextFlag::None {
             return Err(IncapableContext);
         }
-        let in_vec:Vec<*const ffi::PublicKey> = in_keys.iter()
-        .map(|pk| pk.as_ptr())
-        .collect();
+
+        if in_keys.is_empty() {
+            return Err(Error::InvalidParameters);
+        }
+
+        let mut in_vec:Vec<*const ffi::PublicKey> = Vec::with_capacity(in_keys.len());
+        for pk in in_keys {
+            if !pk.is_valid(secp) {
+                return Err(Error::InvalidPublicKey);
+            }
+            in_vec.push(pk.as_ptr());
+        }
+
+        let mut retkey = PublicKey::blank();
         unsafe {
             if ffi::secp256k1_ec_pubkey_combine(secp.ctx, &mut retkey.0 as *mut _,
-                                                  in_vec.as_ptr(), in_vec.len() as i32) == 1 {
+                                                  in_vec.as_ptr(), in_vec.len() as libc::size_t) == 1 {
                 Ok(retkey)
             } else {
                 Err(InvalidPublicKey)
@@ -187,11 +298,50 @@ impl PublicKey {
     }
 
     /// Determines whether a pubkey is valid
-    #[inline]
-    pub fn is_valid(&self) -> bool {
+    pub fn is_valid(&self, secp: &Secp256k1) -> bool {
         // The only invalid pubkey the API should be able to create is
         // the zero one.
-        self.0[..].iter().any(|&x| x != 0)
+        if !self.0[..].iter().any(|&x| x != 0) {
+            return false;
+        }
+
+        let mut illegal = false;
+        let mut ser = [0u8; constants::UNCOMPRESSED_PUBLIC_KEY_SIZE];
+        let mut ser_len = constants::UNCOMPRESSED_PUBLIC_KEY_SIZE as libc::size_t;
+
+        let ok = unsafe {
+            // Note, there is no way to get the current set callback and restore it back
+            // It is expected that callback is short lived and normallu is not set
+            ffi::secp256k1_context_set_illegal_callback(
+                secp.ctx,
+                Some(illegal_cb),
+                &mut illegal as *mut _ as *mut c_void,
+            );
+
+            let ret = ffi::secp256k1_ec_pubkey_serialize(
+                secp.ctx,
+                ser.as_mut_ptr(),
+                &mut ser_len,
+                self.as_ptr(),
+                ffi::SECP256K1_SER_UNCOMPRESSED,
+            );
+
+            // It is the only user of secp library, We know that before callback was None as well.
+            // Also, there is no way to get prev handler
+            ffi::secp256k1_context_set_illegal_callback(secp.ctx, None, ptr::null_mut());
+
+            ret == 1
+                && !illegal
+                && ser_len == constants::UNCOMPRESSED_PUBLIC_KEY_SIZE as libc::size_t
+        };
+
+        ok && PublicKey::from_slice(&secp, &ser).is_ok()
+    }
+
+    /// Get ffi::PublicKey copy
+    #[inline]
+    pub fn as_ffi(&self) -> ffi::PublicKey {
+        self.0
     }
 
     /// Obtains a raw pointer suitable for use with FFI functions
@@ -208,7 +358,15 @@ impl PublicKey {
 
     /// Creates a new public key from a Secp256k1 public key
     #[inline]
-    pub fn from_secp256k1_pubkey(pk: ffi::PublicKey) -> PublicKey { PublicKey(pk) }
+    pub fn from_secp256k1_pubkey(secp: &Secp256k1, pk: ffi::PublicKey) -> Result<PublicKey, Error> {
+        let pk = PublicKey(pk);
+        if !pk.is_valid(secp) {
+            Err(Error::InvalidPublicKey)
+        }
+        else {
+            Ok(pk)
+        }
+    }
 
     /// Creates a new public key from a secret key.
     #[inline]
@@ -219,19 +377,39 @@ impl PublicKey {
             return Err(IncapableContext);
         }
         let mut pk = ffi::PublicKey::blank();
-        unsafe {
+        let res = unsafe {
             // We can assume the return value because it's not possible to construct
             // an invalid `SecretKey` without transmute trickery or something
-            let res = ffi::secp256k1_ec_pubkey_create(secp.ctx, &mut pk, sk.as_ptr());
-            debug_assert_eq!(res, 1);
+            ffi::secp256k1_ec_pubkey_create(secp.ctx, &mut pk, sk.as_ptr())
+        };
+        if res==1 {
+            Ok(PublicKey(pk))
         }
-        Ok(PublicKey(pk))
+        else {
+            Err(InvalidSecretKey)
+        }
     }
 
     /// Creates a public key directly from a slice
     #[inline]
     pub fn from_slice(secp: &Secp256k1, data: &[u8])
                       -> Result<PublicKey, Error> {
+        // Enforce canonical SEC1 encodings here so all callers consistently
+        // reject hybrid 65-byte public keys (0x06/0x07), not just serde paths.
+        match data.len() {
+            constants::COMPRESSED_PUBLIC_KEY_SIZE => {
+                if data.first() != Some(&2) && data.first() != Some(&3) {
+                    return Err(InvalidPublicKey);
+                }
+            }
+            constants::UNCOMPRESSED_PUBLIC_KEY_SIZE => {
+                if data.first() != Some(&4) {
+                    return Err(InvalidPublicKey);
+                }
+            }
+            _ => return Err(InvalidPublicKey),
+        }
+
         let mut pk = ffi::PublicKey::blank();
         unsafe {
             if ffi::secp256k1_ec_pubkey_parse(secp.ctx, &mut pk, data.as_ptr(),
@@ -247,64 +425,101 @@ impl PublicKey {
     /// Serialize the key as a byte-encoded pair of values. In compressed form
     /// the y-coordinate is represented by only a single bit, as x determines
     /// it up to one bit.
-    pub fn serialize_vec(&self, secp: &Secp256k1, compressed: bool) -> ArrayVec<u8, {constants::PUBLIC_KEY_SIZE}> {
-        let mut ret = ArrayVec::new();
-
-        unsafe {
-            let mut ret_len = constants::PUBLIC_KEY_SIZE as ::libc::size_t;
-            let compressed = if compressed { ffi::SECP256K1_SER_COMPRESSED } else { ffi::SECP256K1_SER_UNCOMPRESSED };
-            let err = ffi::secp256k1_ec_pubkey_serialize(secp.ctx, ret.as_ptr(),
-                                                         &mut ret_len, self.as_ptr(),
-                                                         compressed);
-            debug_assert_eq!(err, 1);
-            ret.set_len(ret_len as usize);
+    pub fn serialize_vec(&self, secp: &Secp256k1, compressed: bool) ->
+                                        Result<ArrayVec<u8, {constants::PUBLIC_KEY_SIZE}>, Error>
+    {
+        // Note, not calling is_valid because serialize is a part of validation. No reasons to
+        // serialize it twice
+        if !self.0[..].iter().any(|&x| x != 0) {
+            return Err(InvalidPublicKey)
         }
-        ret
+
+        let mut illegal = false;
+        let mut ret : ArrayVec<u8, {constants::PUBLIC_KEY_SIZE}> = ArrayVec::new();
+        let mut ret_len = constants::PUBLIC_KEY_SIZE as ::libc::size_t;
+        let compressed = if compressed { ffi::SECP256K1_SER_COMPRESSED } else { ffi::SECP256K1_SER_UNCOMPRESSED };
+
+        let ok = unsafe {
+            // Note, there is no way to get the current set callback and restore it back
+            // It is expected that callback is short lived and normallu is not set
+            ffi::secp256k1_context_set_illegal_callback(
+                secp.ctx,
+                Some(illegal_cb),
+                &mut illegal as *mut _ as *mut c_void,
+            );
+
+            let ret = ffi::secp256k1_ec_pubkey_serialize(secp.ctx, ret.as_mut_ptr(),
+                                               &mut ret_len, self.as_ptr(),
+                                               compressed);
+
+            ffi::secp256k1_context_set_illegal_callback(secp.ctx, None, ptr::null_mut());
+
+            ret == 1 && !illegal
+        };
+
+        if ok && ret_len<=constants::PUBLIC_KEY_SIZE {
+            unsafe {
+                ret.set_len(ret_len);
+            }
+            Ok(ret)
+        }
+        else {
+            Err(InvalidPublicKey)
+        }
     }
 
     #[inline]
     /// Adds the pk corresponding to `other` to the pk `self` in place
+    /// Note, in case of error, this PublicKey data can be corrupted
+    /// Note, `other` is passed to `secp256k1_ec_pubkey_tweak_add`, whose implementation is
+    /// not constant time in the tweak value. This method should only be used with public tweak
+    /// values; passing a secret key or other secret-derived scalar may leak it through timing or
+    /// microarchitectural side channels.
     pub fn add_exp_assign(&mut self, secp: &Secp256k1, other: &SecretKey)
                          -> Result<(), Error> {
         if secp.caps == ContextFlag::SignOnly || secp.caps == ContextFlag::None {
             return Err(IncapableContext);
         }
-        unsafe {
-            if ffi::secp256k1_ec_pubkey_tweak_add(secp.ctx, &mut self.0 as *mut _,
-                                                  other.as_ptr()) == 1 {
-                Ok(())
-            } else {
-                Err(InvalidSecretKey)
-            }
+        if !self.is_valid(secp) {
+            return Err(InvalidPublicKey)
+        }
+
+        let res = unsafe {
+            ffi::secp256k1_ec_pubkey_tweak_add(secp.ctx, &mut self.0 as *mut _,
+                                                  other.as_ptr())
+        };
+
+        if res == 1 {
+            Ok(())
+        } else {
+            Err(GenericError)
         }
     }
 
     #[inline]
     /// Muliplies the pk `self` in place by the scalar `other`
+    /// Note, in case of error, this PublicKey data can be corrupted
+    /// Note, some data might leaks through the timing channel, multiplication primitive is not constant time
     pub fn mul_assign(&mut self, secp: &Secp256k1, other: &SecretKey)
                          -> Result<(), Error> {
         if secp.caps == ContextFlag::SignOnly || secp.caps == ContextFlag::None {
             return Err(IncapableContext);
         }
+        if !self.is_valid(secp) {
+            return Err(InvalidPublicKey)
+        }
+
         unsafe {
             if ffi::secp256k1_ec_pubkey_tweak_mul(secp.ctx, &mut self.0 as *mut _,
                                                   other.as_ptr()) == 1 {
                 Ok(())
             } else {
-                Err(InvalidSecretKey)
+                Err(GenericError)
             }
         }
     }
 }
 
-
-/// Creates a new public key from a FFI public key
-impl From<ffi::PublicKey> for PublicKey {
-    #[inline]
-    fn from(pk: ffi::PublicKey) -> PublicKey {
-        PublicKey(pk)
-    }
-}
 
 impl<'de> Deserialize<'de> for PublicKey {
     fn deserialize<D>(d: D) -> Result<PublicKey, D::Error>
@@ -323,7 +538,7 @@ impl<'de> Deserialize<'de> for PublicKey {
             {
                 debug_assert!(constants::UNCOMPRESSED_PUBLIC_KEY_SIZE >= constants::COMPRESSED_PUBLIC_KEY_SIZE);
 
-                let s = Secp256k1::with_caps(crate::ContextFlag::None);
+                let s = Secp256k1::with_caps(ContextFlag::None).unwrap();
                 let mut ret: [u8; constants::UNCOMPRESSED_PUBLIC_KEY_SIZE] = [0u8; constants::UNCOMPRESSED_PUBLIC_KEY_SIZE];
 
                 let mut read_len = 0;
@@ -367,30 +582,36 @@ impl Serialize for PublicKey {
     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
         where S: Serializer
     {
-        let secp = Secp256k1::with_caps(crate::ContextFlag::None);
-        (&self.serialize_vec(&secp, true)[..]).serialize(s)
+        let secp = Secp256k1::with_caps(ContextFlag::None).unwrap();
+        (&self.serialize_vec(&secp, true)
+            .map_err(|e| serde::ser::Error::custom(e.to_string()))?[..])
+        .serialize(s)
     }
 }
 
 #[cfg(test)]
 mod test {
-    extern crate rand_core;
+    use crate::ffi;
+    use std::convert::Infallible;
     use super::super::{Secp256k1, ContextFlag};
-    use super::super::Error::{InvalidPublicKey, InvalidSecretKey, IncapableContext};
+    use super::super::Error::{
+        IncapableContext, InvalidPublicKey, InvalidSecretKey, ZeroSecretKey,
+    };
     use super::{PublicKey, SecretKey};
     use super::super::constants;
 
-    use rand::{Error, RngCore, thread_rng};
-    use self::rand_core::impls;
+    use rand::{TryCryptoRng, TryRng};
+    use rand::rngs::SysRng;
 
     use std::slice::from_raw_parts;
+    use rand::rand_core::utils;
     use crate::key::ONE_KEY;
 
     // This tests cleaning of SecretKey (e.g. secret key) on Drop.
     // To make this test fail, just remove `Zeroize` derive from `SecretKey` definition.
     #[test]
     fn skey_clear_on_drop() {
-        let s = Secp256k1::new();
+        let s = Secp256k1::new().unwrap();
 
         // Create buffer for blinding factor filled with non-zero bytes.
         let sk_bytes = ONE_KEY;
@@ -418,9 +639,9 @@ mod test {
 
     #[test]
     fn skey_from_slice() {
-        let s = Secp256k1::new();
+        let s = Secp256k1::new().unwrap();
         let sk = SecretKey::from_slice(&s, &[1; 31]);
-        assert_eq!(sk, Err(InvalidSecretKey));
+        assert!(sk == Err(InvalidSecretKey));
 
         let sk = SecretKey::from_slice(&s, &[1; 32]);
         assert!(sk.is_ok());
@@ -428,34 +649,51 @@ mod test {
 
     #[test]
     fn pubkey_from_slice() {
-        let s = Secp256k1::new();
+        let s = Secp256k1::new().unwrap();
         assert_eq!(PublicKey::from_slice(&s, &[]), Err(InvalidPublicKey));
         assert_eq!(PublicKey::from_slice(&s, &[1, 2, 3]), Err(InvalidPublicKey));
 
-        let uncompressed = PublicKey::from_slice(&s, &[4, 54, 57, 149, 239, 162, 148, 175, 246, 254, 239, 75, 154, 152, 10, 82, 234, 224, 85, 220, 40, 100, 57, 121, 30, 162, 94, 156, 135, 67, 74, 49, 179, 57, 236, 53, 162, 124, 149, 144, 168, 77, 74, 30, 72, 211, 229, 110, 111, 55, 96, 193, 86, 227, 183, 152, 195, 155, 51, 247, 123, 113, 60, 228, 188]);
+        let uncompressed_bytes = [4, 54, 57, 149, 239, 162, 148, 175, 246, 254, 239, 75, 154, 152, 10, 82, 234, 224, 85, 220, 40, 100, 57, 121, 30, 162, 94, 156, 135, 67, 74, 49, 179, 57, 236, 53, 162, 124, 149, 144, 168, 77, 74, 30, 72, 211, 229, 110, 111, 55, 96, 193, 86, 227, 183, 152, 195, 155, 51, 247, 123, 113, 60, 228, 188];
+        let uncompressed = PublicKey::from_slice(&s, &uncompressed_bytes);
         assert!(uncompressed.is_ok());
 
         let compressed = PublicKey::from_slice(&s, &[3, 23, 183, 225, 206, 31, 159, 148, 195, 42, 67, 115, 146, 41, 248, 140, 11, 3, 51, 41, 111, 180, 110, 143, 114, 134, 88, 73, 198, 174, 52, 184, 78]);
         assert!(compressed.is_ok());
+
+        let mut hybrid = uncompressed_bytes;
+        hybrid[0] = 6;
+        assert_eq!(PublicKey::from_slice(&s, &hybrid), Err(InvalidPublicKey));
+    }
+
+    #[test]
+    fn test_pubkey_is_valid() {
+        let secp = Secp256k1::new().unwrap();
+        let (_, valid_pk) = secp.generate_keypair(&mut SysRng).unwrap();
+        let zero_pk = PublicKey::blank();
+        let invalid_nonzero_pk = PublicKey(ffi::PublicKey([1u8; 64]));
+
+        assert!(valid_pk.is_valid(&secp));
+        assert!(!zero_pk.is_valid(&secp));
+        assert!(!invalid_nonzero_pk.is_valid(&secp));
     }
 
     #[test]
     fn keypair_slice_round_trip() {
-        let s = Secp256k1::new();
+        let s = Secp256k1::new().unwrap();
 
-        let (sk1, pk1) = s.generate_keypair(&mut thread_rng()).unwrap();
-        assert_eq!(SecretKey::from_slice(&s, &sk1[..]), Ok(sk1));
-        assert_eq!(PublicKey::from_slice(&s, &pk1.serialize_vec(&s, true)[..]), Ok(pk1));
-        assert_eq!(PublicKey::from_slice(&s, &pk1.serialize_vec(&s, false)[..]), Ok(pk1));
+        let (sk1, pk1) = s.generate_keypair(&mut SysRng).unwrap();
+        assert!(SecretKey::from_slice(&s, &sk1[..]) == Ok(sk1));
+        assert_eq!(PublicKey::from_slice(&s, &pk1.serialize_vec(&s, true).unwrap()[..]), Ok(pk1));
+        assert_eq!(PublicKey::from_slice(&s, &pk1.serialize_vec(&s, false).unwrap()[..]), Ok(pk1));
     }
 
     #[test]
     fn invalid_secret_key() {
-        let s = Secp256k1::new();
+        let s = Secp256k1::new().unwrap();
         // Zero
-        assert_eq!(SecretKey::from_slice(&s, &[0; 32]), Err(InvalidSecretKey));
+        assert!(SecretKey::from_slice(&s, &[0; 32]) == Err(ZeroSecretKey));
         // -1
-        assert_eq!(SecretKey::from_slice(&s, &[0xff; 32]), Err(InvalidSecretKey));
+        assert!(SecretKey::from_slice(&s, &[0xff; 32]) == Err(InvalidSecretKey));
         // Top of range
         assert!(SecretKey::from_slice(&s,
                                       &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
@@ -472,34 +710,34 @@ mod test {
 
     #[test]
     fn test_pubkey_from_slice_bad_context() {
-        let s = Secp256k1::without_caps();
-        let sk = SecretKey::new(&s, &mut thread_rng());
+        let s = Secp256k1::without_caps().unwrap();
+        let sk = SecretKey::new(&s, &mut SysRng).unwrap();
         assert_eq!(PublicKey::from_secret_key(&s, &sk), Err(IncapableContext));
 
-        let s = Secp256k1::with_caps(ContextFlag::VerifyOnly);
+        let s = Secp256k1::with_caps(ContextFlag::VerifyOnly).unwrap();
         assert_eq!(PublicKey::from_secret_key(&s, &sk), Err(IncapableContext));
 
-        let s = Secp256k1::with_caps(ContextFlag::SignOnly);
+        let s = Secp256k1::with_caps(ContextFlag::SignOnly).unwrap();
         assert!(PublicKey::from_secret_key(&s, &sk).is_ok());
 
-        let s = Secp256k1::with_caps(ContextFlag::Full);
+        let s = Secp256k1::with_caps(ContextFlag::Full).unwrap();
         assert!(PublicKey::from_secret_key(&s, &sk).is_ok());
     }
 
     #[test]
     fn test_add_exp_bad_context() {
-        let s = Secp256k1::with_caps(ContextFlag::Full);
-        let (sk, mut pk) = s.generate_keypair(&mut thread_rng()).unwrap();
+        let s = Secp256k1::with_caps(ContextFlag::Full).unwrap();
+        let (sk, mut pk) = s.generate_keypair(&mut SysRng).unwrap();
 
         assert!(pk.add_exp_assign(&s, &sk).is_ok());
 
-        let s = Secp256k1::with_caps(ContextFlag::VerifyOnly);
+        let s = Secp256k1::with_caps(ContextFlag::VerifyOnly).unwrap();
         assert!(pk.add_exp_assign(&s, &sk).is_ok());
 
-        let s = Secp256k1::with_caps(ContextFlag::SignOnly);
+        let s = Secp256k1::with_caps(ContextFlag::SignOnly).unwrap();
         assert_eq!(pk.add_exp_assign(&s, &sk), Err(IncapableContext));
 
-        let s = Secp256k1::with_caps(ContextFlag::None);
+        let s = Secp256k1::with_caps(ContextFlag::None).unwrap();
         assert_eq!(pk.add_exp_assign(&s, &sk), Err(IncapableContext));
     }
 
@@ -519,6 +757,10 @@ mod test {
         let mut json = json::de::Deserializer::from_str(zero32);
         assert!(<PublicKey as Deserialize>::deserialize(&mut json).is_err());
         let mut json = json::de::Deserializer::from_str(zero32);
+        assert!(<SecretKey as Deserialize>::deserialize(&mut json).is_err()); // Secret key is invalid - no deserializtion
+
+        let valid_secret = "[81,117,240,23,227,126,224,217,105,225,51,45,188,252,144,133,60,209,162,187,183,73,108,79,118,191,49,23,4,33,203,185]";
+        let mut json = json::de::Deserializer::from_str(valid_secret);
         assert!(<SecretKey as Deserialize>::deserialize(&mut json).is_ok());
 
         let zero33 = "[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]";
@@ -526,6 +768,12 @@ mod test {
         assert!(<PublicKey as Deserialize>::deserialize(&mut json).is_err());
         let mut json = json::de::Deserializer::from_str(zero33);
         assert!(<SecretKey as Deserialize>::deserialize(&mut json).is_err());
+
+        let secp = Secp256k1::without_caps().unwrap();
+        let valid_secret = SecretKey::new(&secp, &mut SysRng).unwrap();
+        let vec: Vec<u8> = serde_json::to_vec(&valid_secret).unwrap();
+        let restored: SecretKey = serde_json::from_slice(&vec).unwrap();
+        assert_eq!( valid_secret.0, restored.0 );
 
         let trailing66 = "[4,149,16,196,140,38,92,239,179,65,59,224,230,183,91,238,240,46,186,252,
                         175,102,52,249,98,178,123,72,50,171,196,254,236,1,189,143,242,227,16,87,
@@ -541,6 +789,13 @@ mod test {
                         209,89,236,213,206]";
         let mut json = json::de::Deserializer::from_str(valid65);
         assert!(<PublicKey as Deserialize>::deserialize(&mut json).is_ok());
+
+        let hybrid65 = "[6,149,16,196,140,38,92,239,179,65,59,224,230,183,91,238,240,46,186,252,
+                        175,102,52,249,98,178,123,72,50,171,196,254,236,1,189,143,242,227,16,87,
+                        247,183,162,68,237,140,92,205,151,129,166,58,111,96,123,64,180,147,51,12,
+                        209,89,236,213,206]";
+        let mut json = json::de::Deserializer::from_str(hybrid65);
+        assert!(<PublicKey as Deserialize>::deserialize(&mut json).is_err());
 
         // All zeroes pk is invalid
         let zero65 = "[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]";
@@ -560,9 +815,9 @@ mod test {
 
     #[test]
     fn test_serialize_serde() {
-        let s = Secp256k1::new();
+        let s = Secp256k1::new().unwrap();
         for _ in 0..500 {
-            let (sk, pk) = s.generate_keypair(&mut thread_rng()).unwrap();
+            let (sk, pk) = s.generate_keypair(&mut SysRng).unwrap();
             round_trip_serde!(sk);
             round_trip_serde!(pk);
         }
@@ -572,13 +827,14 @@ mod test {
     fn test_out_of_range() {
 
         struct BadRng(u8);
-        impl RngCore for BadRng {
-            fn next_u32(&mut self) -> u32 { unimplemented!() }
-            fn next_u64(&mut self) -> u64 { unimplemented!() }
+        impl TryRng for BadRng {
+            type Error = Infallible;
+            fn try_next_u32(&mut self) -> Result<u32, Infallible> { unimplemented!() }
+            fn try_next_u64(&mut self) -> Result<u64, Infallible> { unimplemented!() }
             // This will set a secret key to a little over the
             // group order, then decrement with repeated calls
             // until it returns a valid key
-            fn fill_bytes(&mut self, data: &mut [u8]) {
+            fn try_fill_bytes(&mut self, data: &mut [u8]) -> Result<(), Infallible> {
                 let group_order: [u8; 32] = [
                     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
                     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe,
@@ -588,19 +844,19 @@ mod test {
                 data.copy_from_slice(&group_order[..]);
                 data[31] = self.0;
                 self.0 -= 1;
-            }
-            fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-                Ok(self.fill_bytes(dest))
+                Ok(())
             }
         }
 
-        let s = Secp256k1::new();
+        impl TryCryptoRng for BadRng {}
+
+        let s = Secp256k1::new().unwrap();
         s.generate_keypair(&mut BadRng(0xff)).unwrap();
     }
 
     #[test]
     fn test_pubkey_from_bad_slice() {
-        let s = Secp256k1::new();
+        let s = Secp256k1::new().unwrap();
         // Bad sizes
         assert_eq!(PublicKey::from_slice(&s, &[0; constants::COMPRESSED_PUBLIC_KEY_SIZE - 1]),
                    Err(InvalidPublicKey));
@@ -621,58 +877,65 @@ mod test {
     #[test]
     fn test_debug_output() {
         struct DumbRng(u32);
-        impl RngCore for DumbRng {
-            fn next_u32(&mut self) -> u32 {
+        impl TryRng for DumbRng {
+            type Error = Infallible;
+
+            fn try_next_u32(&mut self) -> Result<u32, Infallible> {
                 self.0 = self.0.wrapping_add(1);
-                self.0
+                Ok(self.0)
             }
-            fn next_u64(&mut self) -> u64 {
-                self.next_u32() as u64
+            fn try_next_u64(&mut self) -> Result<u64, Infallible> {
+                self.0 = self.0.wrapping_add(1);
+                Ok(self.0 as u64)
             }
-            fn fill_bytes(&mut self, dest: &mut [u8]) { 
-                impls::fill_bytes_via_next(self, dest)
+            fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Infallible> {
+                utils::fill_bytes_via_next_word( dest, || self.try_next_u64() )
             }
-            fn try_fill_bytes(&mut self, _dest: &mut [u8]) -> Result<(), Error> { unimplemented!() }
         }
 
-        let s = Secp256k1::new();
+        impl TryCryptoRng for DumbRng {}
+
+        let s = Secp256k1::new().unwrap();
         let (sk, _) = s.generate_keypair(&mut DumbRng(0)).unwrap();
 
-        assert_eq!(&format!("{:?}", sk),
-                   "SecretKey(0100000000000000020000000000000003000000000000000400000000000000)");
+        assert_eq!(&format!("{:?}", sk.0),
+                   "[1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0]");
     }
 
     #[test]
     fn test_pubkey_serialize() {
         struct DumbRng(u32);
-        impl RngCore for DumbRng {
-            fn next_u32(&mut self) -> u32 {
+        impl TryRng for DumbRng {
+            type Error = Infallible;
+
+            fn try_next_u32(&mut self) -> Result<u32, Infallible> {
                 self.0 = self.0.wrapping_add(1);
-                self.0
+                Ok(self.0)
             }
-            fn next_u64(&mut self) -> u64 {
-                self.next_u32() as u64
+            fn try_next_u64(&mut self) -> Result<u64, Infallible> {
+                self.try_next_u32().map(|v| v as u64)
             }
-            fn fill_bytes(&mut self, dest: &mut [u8]) { 
-                impls::fill_bytes_via_next(self, dest)
+            fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Infallible> {
+                utils::fill_bytes_via_next_word( dest, || self.try_next_u64() )
             }
-            fn try_fill_bytes(&mut self, _dest: &mut [u8]) -> Result<(), Error> { unimplemented!() }
         }
 
-        let s = Secp256k1::new();
+        impl TryCryptoRng for DumbRng {}
+
+        let s = Secp256k1::new().unwrap();
         let (_, pk1) = s.generate_keypair(&mut DumbRng(0)).unwrap();
-        assert_eq!(&pk1.serialize_vec(&s, false)[..],
+        assert_eq!(&pk1.serialize_vec(&s, false).unwrap()[..],
                    &[4, 124, 121, 49, 14, 253, 63, 197, 50, 39, 194, 107, 17, 193, 219, 108, 154, 126, 9, 181, 248, 2, 12, 149, 233, 198, 71, 149, 134, 250, 184, 154, 229, 185, 28, 165, 110, 27, 3, 162, 126, 238, 167, 157, 242, 221, 76, 251, 237, 34, 231, 72, 39, 245, 3, 191, 64, 111, 170, 117, 103, 82, 28, 102, 163][..]);
-        assert_eq!(&pk1.serialize_vec(&s, true)[..],
+        assert_eq!(&pk1.serialize_vec(&s, true).unwrap()[..],
                    &[3, 124, 121, 49, 14, 253, 63, 197, 50, 39, 194, 107, 17, 193, 219, 108, 154, 126, 9, 181, 248, 2, 12, 149, 233, 198, 71, 149, 134, 250, 184, 154, 229][..]);
     }
 
     #[test]
     fn test_addition() {
-        let s = Secp256k1::new();
+        let s = Secp256k1::new().unwrap();
 
-        let (mut sk1, mut pk1) = s.generate_keypair(&mut thread_rng()).unwrap();
-        let (mut sk2, mut pk2) = s.generate_keypair(&mut thread_rng()).unwrap();
+        let (mut sk1, mut pk1) = s.generate_keypair(&mut SysRng).unwrap();
+        let (mut sk2, mut pk2) = s.generate_keypair(&mut SysRng).unwrap();
 
         assert_eq!(PublicKey::from_secret_key(&s, &sk1).unwrap(), pk1);
         assert!(sk1.add_assign(&s, &sk2).is_ok());
@@ -687,10 +950,10 @@ mod test {
 
     #[test]
     fn test_multiplication() {
-        let s = Secp256k1::new();
+        let s = Secp256k1::new().unwrap();
 
-        let (mut sk1, mut pk1) = s.generate_keypair(&mut thread_rng()).unwrap();
-        let (mut sk2, mut pk2) = s.generate_keypair(&mut thread_rng()).unwrap();
+        let (mut sk1, mut pk1) = s.generate_keypair(&mut SysRng).unwrap();
+        let (mut sk2, mut pk2) = s.generate_keypair(&mut SysRng).unwrap();
 
         assert_eq!(PublicKey::from_secret_key(&s, &sk1).unwrap(), pk1);
         assert!(sk1.mul_assign(&s, &sk2).is_ok());
@@ -705,10 +968,10 @@ mod test {
 
     #[test]
     fn test_pk_combination() {
-        let s = Secp256k1::new();
+        let s = Secp256k1::new().unwrap();
 
-        let (sk1, mut pk1) = s.generate_keypair(&mut thread_rng()).unwrap();
-        let (sk2, mut pk2) = s.generate_keypair(&mut thread_rng()).unwrap();
+        let (sk1, mut pk1) = s.generate_keypair(&mut SysRng).unwrap();
+        let (sk2, mut pk2) = s.generate_keypair(&mut SysRng).unwrap();
 
         let combined_pk = PublicKey::from_combination(&s, vec![&pk1,&pk2]).unwrap();
 
@@ -720,7 +983,7 @@ mod test {
 
     #[test]
     fn test_inverse() {
-        let s = Secp256k1::new();
+        let s = Secp256k1::new().unwrap();
 
         let one = SecretKey::from_slice(&s, &[
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -730,37 +993,37 @@ mod test {
 
         let mut one_inv: SecretKey = one.clone();
         one_inv.inv_assign(&s).unwrap();
-        assert_eq!(one_inv, one);
+        assert!(one_inv == one);
 
-        let (sk1, _) = s.generate_keypair(&mut thread_rng()).unwrap();
+        let (sk1, _) = s.generate_keypair(&mut SysRng).unwrap();
         let mut sk2: SecretKey = sk1.clone();
         sk2.inv_assign(&s).unwrap();
         sk2.inv_assign(&s).unwrap();
-        assert_eq!(sk2, sk1);
+        assert!(sk2 == sk1);
 
-        let (sk1, _) = s.generate_keypair(&mut thread_rng()).unwrap();
+        let (sk1, _) = s.generate_keypair(&mut SysRng).unwrap();
         let mut sk2: SecretKey = sk1.clone();
         sk2.inv_assign(&s).unwrap();
         sk2.mul_assign(&s, &sk1).unwrap();
-        assert_eq!(sk2, one);
+        assert!(sk2 == one);
     }
 
     #[test]
     fn test_negate() {
-        let s = Secp256k1::new();
+        let s = Secp256k1::new().unwrap();
 
-        let (sk1, _) = s.generate_keypair(&mut thread_rng()).unwrap();
+        let (sk1, _) = s.generate_keypair(&mut SysRng).unwrap();
         let mut sk2: SecretKey = sk1.clone();
         sk2.neg_assign(&s).unwrap();
         assert!(sk2.add_assign(&s, &sk1).is_err());
 
-        let (sk1, _) = s.generate_keypair(&mut thread_rng()).unwrap();
+        let (sk1, _) = s.generate_keypair(&mut SysRng).unwrap();
         let mut sk2: SecretKey = sk1.clone();
         sk2.neg_assign(&s).unwrap();
         sk2.neg_assign(&s).unwrap();
-        assert_eq!(sk2, sk1);
+        assert!(sk2 == sk1);
 
-        let (mut sk1, _) = s.generate_keypair(&mut thread_rng()).unwrap();
+        let (mut sk1, _) = s.generate_keypair(&mut SysRng).unwrap();
         let mut sk2: SecretKey = sk1.clone();
         sk1.neg_assign(&s).unwrap();
         let sk1_clone = sk1.clone();
@@ -768,7 +1031,7 @@ mod test {
         let sk2_clone = sk2.clone();
         sk2.add_assign(&s, &sk2_clone).unwrap();
         sk2.neg_assign(&s).unwrap();
-        assert_eq!(sk2, sk1);
+        assert!(sk2 == sk1);
 
         let one = SecretKey::from_slice(&s, &[
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -776,20 +1039,20 @@ mod test {
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]).unwrap();
 
-        let (mut sk1, _) = s.generate_keypair(&mut thread_rng()).unwrap();
+        let (mut sk1, _) = s.generate_keypair(&mut SysRng).unwrap();
         let mut sk2: SecretKey = one.clone();
         sk2.neg_assign(&s).unwrap();
         sk2.mul_assign(&s, &sk1).unwrap();
         sk1.neg_assign(&s).unwrap();
-        assert_eq!(sk2, sk1);
+        assert!(sk2 == sk1);
 
-        let (mut sk1, _) = s.generate_keypair(&mut thread_rng()).unwrap();
+        let (mut sk1, _) = s.generate_keypair(&mut SysRng).unwrap();
         let mut sk2: SecretKey = sk1.clone();
         sk1.neg_assign(&s).unwrap();
         sk1.inv_assign(&s).unwrap();
         sk2.inv_assign(&s).unwrap();
         sk2.neg_assign(&s).unwrap();
-        assert_eq!(sk2, sk1);
+        assert!(sk2 == sk1);
     }
 
     #[test]
@@ -804,11 +1067,11 @@ mod test {
             s.finish()
         }
 
-        let s = Secp256k1::new();
+        let s = Secp256k1::new().unwrap();
         let mut set = HashSet::new();
         const COUNT : usize = 1024;
         let count = (0..COUNT).map(|_| {
-            let (_, pk) = s.generate_keypair(&mut thread_rng()).unwrap();
+            let (_, pk) = s.generate_keypair(&mut SysRng).unwrap();
             let hash = hash(&pk);
             assert!(!set.contains(&hash));
             set.insert(hash);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,25 +32,17 @@
 #![deny(unused_mut)]
 #![warn(missing_docs)]
 
-#![cfg_attr(feature = "dev", allow(unstable_features))]
-#![cfg_attr(feature = "dev", feature(plugin))]
-#![cfg_attr(feature = "dev", plugin(clippy))]
-
 #![cfg_attr(all(test, feature = "unstable"), feature(test))]
 #[cfg(all(test, feature = "unstable"))] extern crate test;
 
-extern crate arrayvec;
-extern crate serde;
 extern crate serde_json as json;
-
-extern crate libc;
-pub extern crate rand;
-
-extern crate zeroize;
 
 use libc::size_t;
 use std::{fmt, ops, ptr};
-use rand::Rng;
+use std::ptr::NonNull;
+use rand::rngs::SysRng;
+use rand::TryCryptoRng;
+use zeroize::Zeroize;
 
 #[macro_use]
 mod macros;
@@ -64,18 +56,65 @@ pub mod aggsig;
 pub use key::SecretKey;
 pub use key::PublicKey;
 
+// Reexport crates, so mwc can reuse them
+pub use arrayvec;
+pub use rand;
+pub use libc;
+pub use serde;
+pub use serde_json;
+pub use zeroize;
+
 /// A tag used for recovering the public key from a compact signature
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct RecoveryId(i32);
 
 /// An ECDSA signature
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub struct Signature(ffi::Signature);
+pub struct EcdsaSignature(ffi::Signature);
 
-impl std::convert::AsRef<[u8]> for Signature {
-    fn as_ref(&self) -> &[u8] {
-        &self.0.as_ref()
+/// An aggsig / Schnorr signature in aggsig's 64-byte format
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct AggSigSignature(ffi::Signature);
+
+const SECP256K1_FIELD_PRIME: [u8; 32] = [
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFE, 0xFF, 0xFF, 0xFC, 0x2F,
+];
+
+fn b32_is_zero(bytes: &[u8]) -> bool {
+    bytes.iter().all(|&b| b == 0)
+}
+
+fn b32_is_less_than(bytes: &[u8], upper_bound: &[u8; 32]) -> bool {
+    if bytes.len() != 32 {
+        return false;
     }
+    for (byte, upper) in bytes.iter().zip(upper_bound.iter()) {
+        if byte < upper {
+            return true;
+        }
+        if byte > upper {
+            return false;
+        }
+    }
+    false
+}
+
+fn aggsig_rx_bytes_are_valid(bytes: &[u8]) -> bool {
+    bytes.len() == 32 && !b32_is_zero(bytes) && b32_is_less_than(bytes, &SECP256K1_FIELD_PRIME)
+}
+
+fn aggsig_rx_lifts_to_point(secp: &Secp256k1, bytes: &[u8]) -> bool {
+    if !aggsig_rx_bytes_are_valid(bytes) {
+        return false;
+    }
+
+    let mut compressed = [0u8; constants::COMPRESSED_PUBLIC_KEY_SIZE];
+    compressed[0] = 0x02;
+    compressed[1..].copy_from_slice(bytes);
+    PublicKey::from_slice(secp, &compressed).is_ok()
 }
 
 /// An AggSig partial signature
@@ -109,54 +148,143 @@ impl RecoveryId {
     }
 }
 
-impl Signature {
+macro_rules! impl_signature_wrapper {
+    ($name:ident) => {
+        impl $name {
+            /// Create a new (zeroed) signature usable for the FFI interface
+            pub fn new() -> $name {
+                $name(ffi::Signature::new())
+            }
+
+            /// Obtains a raw pointer suitable for use with FFI functions
+            #[inline]
+            pub fn as_ptr(&self) -> *const ffi::Signature {
+                &self.0 as *const _
+            }
+
+            /// Obtains a raw mutable pointer suitable for use with FFI functions
+            #[inline]
+            pub fn as_mut_ptr(&mut self) -> *mut ffi::Signature {
+                &mut self.0 as *mut _
+            }
+        }
+
+        impl ops::Index<usize> for $name {
+            type Output = u8;
+
+            #[inline]
+            fn index(&self, index: usize) -> &u8 {
+                &self.0[index]
+            }
+        }
+
+        impl ops::Index<ops::Range<usize>> for $name {
+            type Output = [u8];
+
+            #[inline]
+            fn index(&self, index: ops::Range<usize>) -> &[u8] {
+                &self.0[index]
+            }
+        }
+
+        impl ops::Index<ops::RangeFrom<usize>> for $name {
+            type Output = [u8];
+
+            #[inline]
+            fn index(&self, index: ops::RangeFrom<usize>) -> &[u8] {
+                &self.0[index.start..]
+            }
+        }
+
+        impl ops::Index<ops::RangeFull> for $name {
+            type Output = [u8];
+
+            #[inline]
+            fn index(&self, _: ops::RangeFull) -> &[u8] {
+                &self.0[..]
+            }
+        }
+    };
+}
+
+// Note: EcdsaSignature storing data in internal format, not in not a canonical DER or 64-byte compact encoding
+//     Use raw data access for logs and debug.
+impl_signature_wrapper!(EcdsaSignature);
+impl_signature_wrapper!(AggSigSignature);
+
+// Note: This API exposing signature internals. We understand that it is not a good way to expose signature,
+//    but there is a legacy code that already using that, we can't switch to compact style for signature data.
+impl std::convert::AsRef<[u8]> for AggSigSignature {
+    fn as_ref(&self) -> &[u8] {
+        &self.0.as_ref()
+    }
+}
+
+impl EcdsaSignature {
+    /// Checks whether the signature is non-zero and compact-serializes to scalars in range.
+    /// This validates encoding shape only; it does not verify the signature against a message.
+    pub fn is_valid(&self, secp: &Secp256k1) -> bool {
+        match self.serialize_compact(secp) {
+            Ok(compact) => {
+                SecretKey::from_slice(secp, &compact[..32]).is_ok() &&
+                SecretKey::from_slice(secp, &compact[32..]).is_ok()
+            }
+            Err(_) => false,
+        }
+    }
+
     #[inline]
     /// Converts a DER-encoded byte slice to a signature
-    pub fn from_der(secp: &Secp256k1, data: &[u8]) -> Result<Signature, Error> {
-        let mut ret = ffi::Signature::blank();
+    /// Note: Error InvalidSignature might be related to some invariant failures
+    pub fn from_der(secp: &Secp256k1, data: &[u8]) -> Result<EcdsaSignature, Error> {
+        let mut ret = EcdsaSignature::new();
 
         unsafe {
-            if ffi::secp256k1_ecdsa_signature_parse_der(secp.ctx, &mut ret,
-                                                        data.as_ptr(), data.len() as libc::size_t) == 1 {
-                Ok(Signature(ret))
+            if ffi::secp256k1_ecdsa_signature_parse_der(secp.ctx, ret.as_mut_ptr(),
+                                                        data.as_ptr(), data.len() as libc::size_t) == 1
+                && ret.is_valid(secp)
+            {
+                Ok(ret)
             } else {
                 Err(Error::InvalidSignature)
             }
         }
     }
 
-    /// Converts a 64-byte compact-encoded byte slice to a signature
-    pub fn from_compact(secp: &Secp256k1, data: &[u8]) -> Result<Signature, Error> {
-        let mut ret = ffi::Signature::blank();
+    /// Converts a 64-byte compact-encoded byte slice to a signature.
+    /// Note: Error InvalidSignature might be related to some invariant failures
+    pub fn from_compact(secp: &Secp256k1, data: &[u8]) -> Result<EcdsaSignature, Error> {
+        let mut ret = EcdsaSignature::new();
         if data.len() != 64 {
             return Err(Error::InvalidSignature);
         }
 
-        unsafe {
-            if ffi::secp256k1_ecdsa_signature_parse_compact(secp.ctx, &mut ret,
-                                                            data.as_ptr()) == 1 {
-                Ok(Signature(ret))
-            } else {
-                Err(Error::InvalidSignature)
+        let ok = unsafe {
+            ffi::secp256k1_ecdsa_signature_parse_compact(secp.ctx, ret.as_mut_ptr(),
+                                                            data.as_ptr())
+        };
+
+        if ok==1 {
+            if ret.is_valid(secp) {
+                return Ok(ret);
             }
         }
-    }
-
-    /// Stores raw bytes provided as a signature, with no conversion
-    pub fn from_raw_data(data: &[u8;64]) -> Result<Signature, Error> {
-        Ok(Signature(ffi::Signature::from_data(data.clone())))
+        Err(Error::InvalidSignature)
     }
 
     /// Converts a "lax DER"-encoded byte slice to a signature. This is basically
     /// only useful for validating signatures in the Bitcoin blockchain from before
     /// 2016. It should never be used in new applications. This library does not
     /// support serializing to this "format"
-    pub fn from_der_lax(secp: &Secp256k1, data: &[u8]) -> Result<Signature, Error> {
+    /// Note: This method return "DER shape was tolerated” with “signature parsed successfully."
+    ///     Malformed signature canbe created because of that parsing.
+    /// Note:  mwc-node & mwc-wallet should never use this API.
+    pub fn from_der_lax(secp: &Secp256k1, data: &[u8]) -> Result<EcdsaSignature, Error> {
         unsafe {
-            let mut ret = ffi::Signature::blank();
-            if ffi::ecdsa_signature_parse_der_lax(secp.ctx, &mut ret,
+            let mut ret = EcdsaSignature::new();
+            if ffi::ecdsa_signature_parse_der_lax(secp.ctx, ret.as_mut_ptr(),
                                                   data.as_ptr(), data.len() as libc::size_t) == 1 {
-                Ok(Signature(ret))
+                Ok(ret)
             } else {
                 Err(Error::InvalidSignature)
             }
@@ -180,85 +308,189 @@ impl Signature {
     /// valid. (For example, parsing the historic Bitcoin blockchain requires
     /// this.) For these applications we provide this normalization function,
     /// which ensures that the s value lies in the lower half of its range.
-    pub fn normalize_s(&mut self, secp: &Secp256k1) {
-        unsafe {
+    pub fn normalize_s(&mut self, secp: &Secp256k1) -> Result<(), Error> {
+        let ok = unsafe {
             // Ignore return value, which indicates whether the sig
             // was already normalized. We don't care.
             ffi::secp256k1_ecdsa_signature_normalize(secp.ctx, self.as_mut_ptr(),
-                                                     self.as_ptr());
+                                                     self.as_ptr())
+        };
+        if ok == 0 {
+            Err(Error::InvalidSignature)
         }
-    }
-
-    /// Obtains a raw pointer suitable for use with FFI functions
-    #[inline]
-    pub fn as_ptr(&self) -> *const ffi::Signature {
-        &self.0 as *const _
-    }
-
-    /// Obtains a raw mutable pointer suitable for use with FFI functions
-    #[inline]
-    pub fn as_mut_ptr(&mut self) -> *mut ffi::Signature {
-        &mut self.0 as *mut _
+        else {
+            Ok(())
+        }
     }
 
     #[inline]
     /// Serializes the signature in DER format
-    pub fn serialize_der(&self, secp: &Secp256k1) -> Vec<u8> {
-        let mut ret = Vec::with_capacity(72);
-        let mut len: size_t = ret.capacity() as size_t;
-        unsafe {
-            let err = ffi::secp256k1_ecdsa_signature_serialize_der(secp.ctx, ret.as_mut_ptr(),
-                                                                   &mut len, self.as_ptr());
-            debug_assert!(err == 1);
-            ret.set_len(len as usize);
+    pub fn serialize_der(&self, secp: &Secp256k1) -> Result<Vec<u8>, Error> {
+        const RES_CAPACITY : usize = 72;
+        let mut ret = vec![0; RES_CAPACITY];
+        let mut len: size_t = ret.len() as size_t;
+        let ok = unsafe {
+            ffi::secp256k1_ecdsa_signature_serialize_der(secp.ctx, ret.as_mut_ptr(),
+                                                                   &mut len, self.as_ptr())
+        };
+        if ok==1 && len<=RES_CAPACITY {
+            ret.truncate(len as usize);
+            Ok(ret)
         }
-        ret
+        else {
+            Err(Error::SerializationError)
+        }
+
     }
 
     #[inline]
     /// Serializes the signature in compact format
-    pub fn serialize_compact(&self, secp: &Secp256k1) -> [u8; 64] {
+    pub fn serialize_compact(&self, secp: &Secp256k1) -> Result<[u8; 64], Error> {
         let mut ret = [0; 64];
-        unsafe {
-            let err = ffi::secp256k1_ecdsa_signature_serialize_compact(secp.ctx, ret.as_mut_ptr(),
-                                                                       self.as_ptr());
-            debug_assert!(err == 1);
+        let ok = unsafe {
+            ffi::secp256k1_ecdsa_signature_serialize_compact(secp.ctx, ret.as_mut_ptr(),
+                                                                       self.as_ptr())
+        };
+        if ok==1 {
+            Ok(ret)
         }
-        ret
+        else {
+            Err(Error::SerializationError)
+        }
     }
 
-    #[inline]
-    /// Just return raw data, no conversion tricks
-    pub fn to_raw_data(&self) -> [u8; 64] {
-        (self.0).0.clone()
-    }
 }
 
-impl serde::Serialize for Signature {
+impl AggSigSignature {
+    /// Blank invalid signature
+    pub fn blank() -> AggSigSignature {
+        AggSigSignature(ffi::Signature([0u8; constants::AGG_SIGNATURE_SIZE]))
+    }
+
+    /// Checks whether the aggsig signature is well-formed as a 64-byte `(R.x || s)` encoding.
+    ///
+    /// This validates encoding shape only; it does not verify the signature against a message.
+    /// Note: It rejects `s == 0` signature which can be false positive. We are accepting that
+    ///    because we want to reject the blank signatures
+    pub fn is_valid(&self, secp: &Secp256k1) -> bool {
+        aggsig_rx_lifts_to_point(secp, &self[0..32]) &&
+        SecretKey::from_slice(secp, &self[32..]).is_ok()
+    }
+
+    /// Converts a 64-byte compact-encoded byte slice to a signature.
+    /// Note: compact format is slightly different from raw format, the 32 byte parts are swapped.
+    /// Note: Error InvalidSignature might be related to some invariant failures
+    pub fn from_compact(secp: &Secp256k1, data: &[u8]) -> Result<AggSigSignature, Error> {
+        let mut ret = AggSigSignature::new();
+        if data.len() != 64 {
+            return Err(Error::InvalidSignature);
+        }
+
+        let ok = unsafe {
+            ffi::secp256k1_ecdsa_signature_parse_compact(secp.ctx, ret.as_mut_ptr(),
+                                                         data.as_ptr())
+        };
+
+        if ok==1 {
+            if ret.is_valid(secp) {
+                return Ok(ret);
+            }
+        }
+        Err(Error::InvalidSignature)
+    }
+
+    /// Serializes the aggsig signature through the legacy ECDSA compact serializer.
+    ///
+    /// This is not the raw aggsig `(R.x || s)` wire encoding. Use `to_raw_data` when the caller
+    /// needs to preserve aggsig bytes exactly, such as JSON or network interchange.
+    pub fn serialize_compact(
+        &self,
+        secp: &Secp256k1,
+    ) -> Result<[u8; constants::AGG_SIGNATURE_SIZE], Error> {
+        let mut ret = [0; 64];
+        let ok = unsafe {
+            ffi::secp256k1_ecdsa_signature_serialize_compact(secp.ctx, ret.as_mut_ptr(),
+                                                             self.as_ptr())
+        };
+        if ok==1 {
+            Ok(ret)
+        }
+        else {
+            Err(Error::SerializationError)
+        }
+    }
+
+    /// Returns the raw aggsig `(R.x || s)` bytes after validating the signature shape.
+    ///
+    /// Aggsig signatures are stored internally in the same raw wire format used by aggsig
+    /// serialization. This method exists so aggsig callers do not need to go through the ECDSA
+    /// compact serializer, which can transform the bytes and is the wrong encoding for Schnorr
+    /// aggsig interchange.
+    pub fn to_raw_data(
+        &self,
+        secp: &Secp256k1,
+    ) -> Result<[u8; constants::AGG_SIGNATURE_SIZE], Error> {
+        if !self.is_valid(secp) {
+            return Err(Error::InvalidSignature);
+        }
+        Ok(self.0.0)
+    }
+
+    /// Serializes the raw aggsig `(R.x || s)` wire bytes without ECDSA conversion.
+    ///
+    /// This is an alias for `to_raw_data` with a serialization-oriented name for call sites that
+    /// are writing aggsig signatures to external formats.
+    pub fn serialize_raw(
+        &self,
+        secp: &Secp256k1,
+    ) -> Result<[u8; constants::AGG_SIGNATURE_SIZE], Error> {
+        self.to_raw_data(secp)
+    }
+
+    /// Stores raw bytes provided as a signature, with no conversion
+    pub fn from_raw_data(secp: &Secp256k1, data: &[u8;constants::AGG_SIGNATURE_SIZE]) -> Result<AggSigSignature, Error> {
+        let sign = AggSigSignature(ffi::Signature(data.clone()));
+        if sign.is_valid(secp) {
+            Ok(sign)
+        }
+        else {
+            Err(Error::InvalidSignature)
+        }
+    }
+
+}
+
+impl serde::Serialize for EcdsaSignature {
     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
         where S: serde::Serializer
     {
-        let secp = Secp256k1::with_caps(crate::ContextFlag::None);
-        (&self.serialize_compact(&secp)[..]).serialize(s)
+        let secp = Secp256k1::with_caps(ContextFlag::None)
+            .map_err(|e| serde::ser::Error::custom(format!("Failed to create secp context, {}", e)))?;
+        (&self.serialize_compact(&secp)
+            .map_err(|e| serde::ser::Error::custom(format!("Signature serialization error, {}", e)))?
+            [..]
+        ).serialize(s)
     }
 }
 
-impl<'de> serde::Deserialize<'de> for Signature {
-    fn deserialize<D>(d: D) -> Result<Signature, D::Error>
+impl<'de> serde::Deserialize<'de> for EcdsaSignature {
+    fn deserialize<D>(d: D) -> Result<EcdsaSignature, D::Error>
         where D: serde::Deserializer<'de>
     {
         use serde::de;
         struct Visitor {
-            marker: std::marker::PhantomData<Signature>,
+            marker: std::marker::PhantomData<EcdsaSignature>,
         }
         impl<'de> de::Visitor<'de> for Visitor {
-            type Value = Signature;
+            type Value = EcdsaSignature;
 
             #[inline]
-            fn visit_seq<A>(self, mut a: A) -> Result<Signature, A::Error>
+            fn visit_seq<A>(self, mut a: A) -> Result<EcdsaSignature, A::Error>
                 where A: de::SeqAccess<'de>
             {
-                let s = Secp256k1::with_caps(crate::ContextFlag::None);
+                let s = Secp256k1::with_caps(ContextFlag::None)
+                    .map_err(|e| serde::de::Error::custom(format!("Failed to create secp context, {}", e)))?;
+
                 let mut ret: [u8; constants::COMPACT_SIGNATURE_SIZE] = [0u8; constants::COMPACT_SIGNATURE_SIZE];
 
                 for i in 0..constants::COMPACT_SIGNATURE_SIZE {
@@ -272,7 +504,7 @@ impl<'de> serde::Deserialize<'de> for Signature {
                     return Err(serde::de::Error::invalid_length(constants::COMPACT_SIGNATURE_SIZE + 1, &self));
                 }
 
-                Signature::from_compact(&s, &ret).map_err(
+                EcdsaSignature::from_compact(&s, &ret).map_err(
                     |e| match e {
                         Error::InvalidSignature => de::Error::invalid_value(de::Unexpected::Seq, &self),
                         _ => de::Error::custom(&e.to_string()),
@@ -291,14 +523,6 @@ impl<'de> serde::Deserialize<'de> for Signature {
     }
 }
 
-/// Creates a new signature from a FFI signature
-impl From<ffi::Signature> for Signature {
-    #[inline]
-    fn from(sig: ffi::Signature) -> Signature {
-        Signature(sig)
-    }
-}
-
 impl AggSigPartialSignature {
     /// Obtains a raw pointer suitable for use with FFI functions
     #[inline]
@@ -311,6 +535,13 @@ impl AggSigPartialSignature {
     pub fn as_mut_ptr(&mut self) -> *mut ffi::AggSigPartialSignature {
         &mut self.0 as *mut _
     }
+
+    /// Copy of ffi representaiton of the signature
+    #[inline]
+    pub fn as_ffi(&self) -> ffi::AggSigPartialSignature {
+        self.0
+    }
+
 }
 
 /// Creates a new signature from a FFI signature
@@ -323,22 +554,33 @@ impl From<ffi::AggSigPartialSignature> for AggSigPartialSignature {
 
 
 impl RecoverableSignature {
+    /// Create a new zero filled instance of signature
+    pub fn new() -> RecoverableSignature
+    {
+        RecoverableSignature(crate::ffi::RecoverableSignature::new())
+    }
+
     #[inline]
     /// Converts a compact-encoded byte slice to a signature. This
     /// representation is nonstandard and defined by the libsecp256k1
     /// library.
     pub fn from_compact(secp: &Secp256k1, data: &[u8], recid: RecoveryId) -> Result<RecoverableSignature, Error> {
-        let mut ret = ffi::RecoverableSignature::blank();
+        let mut ret = RecoverableSignature::new();
 
-        unsafe {
-            if data.len() != 64 {
-                Err(Error::InvalidSignature)
-            } else if ffi::secp256k1_ecdsa_recoverable_signature_parse_compact(secp.ctx, &mut ret,
-                                                                               data.as_ptr(), recid.0) == 1 {
-                Ok(RecoverableSignature(ret))
-            } else {
-                Err(Error::InvalidSignature)
-            }
+        if data.len() != 64 {
+            return Err(Error::InvalidSignature);
+        }
+
+        let ok = unsafe {
+            ffi::secp256k1_ecdsa_recoverable_signature_parse_compact(secp.ctx, ret.as_mut_ptr(),
+                                                                     data.as_ptr(), recid.0)
+        };
+
+        if ok == 1 {
+            Ok(ret)
+        } else
+        {
+            Err(Error::InvalidSignature)
         }
     }
 
@@ -348,73 +590,45 @@ impl RecoverableSignature {
         &self.0 as *const _
     }
 
+    /// Obtains a raw mutable pointer suitable for use with FFI functions
+    #[inline]
+    pub fn as_mut_ptr(&mut self) -> *mut ffi::RecoverableSignature {
+        &mut self.0 as *mut _
+    }
+
     #[inline]
     /// Serializes the recoverable signature in compact format
-    pub fn serialize_compact(&self, secp: &Secp256k1) -> (RecoveryId, [u8; 64]) {
+    pub fn serialize_compact(&self, secp: &Secp256k1) -> Result<(RecoveryId, [u8; 64]), Error> {
         let mut ret = [0u8; 64];
         let mut recid = 0i32;
-        unsafe {
-            let err = ffi::secp256k1_ecdsa_recoverable_signature_serialize_compact(
-                secp.ctx, ret.as_mut_ptr(), &mut recid, self.as_ptr());
-            assert!(err == 1);
+        let err = unsafe {
+            ffi::secp256k1_ecdsa_recoverable_signature_serialize_compact(
+                secp.ctx, ret.as_mut_ptr(), &mut recid, self.as_ptr())
+        };
+
+        if err==1 {
+            Ok((RecoveryId(recid), ret))
         }
-        (RecoveryId(recid), ret)
+        else {
+            Err(Error::InvalidSignature)
+        }
     }
 
     /// Converts a recoverable signature to a non-recoverable one (this is needed
     /// for verification
+    /// Note: Error InvalidSignature might be related to some invariant failures
     #[inline]
-    pub fn to_standard(&self, secp: &Secp256k1) -> Signature {
-        let mut ret = ffi::Signature::blank();
-        unsafe {
-            let err = ffi::secp256k1_ecdsa_recoverable_signature_convert(secp.ctx, &mut ret, self.as_ptr());
-            assert!(err == 1);
+    pub fn to_standard(&self, secp: &Secp256k1) -> Result<EcdsaSignature, Error> {
+        let mut ret = EcdsaSignature::new();
+        let ok = unsafe {
+            ffi::secp256k1_ecdsa_recoverable_signature_convert(secp.ctx, ret.as_mut_ptr(), self.as_ptr())
+        };
+        if ok==1 && ret.is_valid(secp) {
+            Ok(ret)
         }
-        Signature(ret)
-    }
-}
-
-/// Creates a new recoverable signature from a FFI one
-impl From<ffi::RecoverableSignature> for RecoverableSignature {
-    #[inline]
-    fn from(sig: ffi::RecoverableSignature) -> RecoverableSignature {
-        RecoverableSignature(sig)
-    }
-}
-
-impl ops::Index<usize> for Signature {
-    type Output = u8;
-
-    #[inline]
-    fn index(&self, index: usize) -> &u8 {
-        &self.0[index]
-    }
-}
-
-impl ops::Index<ops::Range<usize>> for Signature {
-    type Output = [u8];
-
-    #[inline]
-    fn index(&self, index: ops::Range<usize>) -> &[u8] {
-        &self.0[index]
-    }
-}
-
-impl ops::Index<ops::RangeFrom<usize>> for Signature {
-    type Output = [u8];
-
-    #[inline]
-    fn index(&self, index: ops::RangeFrom<usize>) -> &[u8] {
-        &self.0[index.start..]
-    }
-}
-
-impl ops::Index<ops::RangeFull> for Signature {
-    type Output = [u8];
-
-    #[inline]
-    fn index(&self, _: ops::RangeFull) -> &[u8] {
-        &self.0[..]
+        else {
+            Err(Error::InvalidSignature)
+        }
     }
 }
 
@@ -422,6 +636,7 @@ impl ops::Index<ops::RangeFull> for Signature {
 pub struct Message([u8; constants::MESSAGE_SIZE]);
 impl Copy for Message {}
 impl_array_newtype!(Message, u8, constants::MESSAGE_SIZE);
+// Note, message doesn't contain sensitive data, so it can be dumped with Debug output
 impl_pretty_debug!(Message);
 
 impl Message {
@@ -465,6 +680,8 @@ pub enum Error {
     InvalidSignature,
     /// Bad secret key
     InvalidSecretKey,
+    /// Secret key is zero
+    ZeroSecretKey,
     /// Bad recovery id
     InvalidRecoveryId,
     /// Summing commitments led to incorrect result
@@ -475,6 +692,22 @@ pub enum Error {
     PartialSigFailure,
     /// Failure subtracting two signatures
     SigSubtractionFailure,
+    /// System random generator error
+    SysRngFailure,
+    /// Generic Secp Error, should be almost impossible to hit
+    GenericError,
+    /// Range proof generation failure. Very small chance
+    RangeProofGeneration,
+    /// Nonce export failure
+    NonceExportError,
+    /// Invalid parameters
+    InvalidParameters,
+    /// Serialization error
+    SerializationError,
+    /// Instance allcotion error
+    AllocationError,
+    /// AggSigContext is broken
+    BrokenAggSigContext,
 }
 
 impl Error {
@@ -487,35 +720,43 @@ impl Error {
             Error::InvalidCommit => "secp: malformed commit",
             Error::InvalidSignature => "secp: malformed signature",
             Error::InvalidSecretKey => "secp: malformed or out-of-range secret key",
+            Error::ZeroSecretKey => "secp: zero secret key",
             Error::InvalidRecoveryId => "secp: bad recovery id",
             Error::IncorrectCommitSum => "secp: invalid pedersen commitment sum",
             Error::InvalidRangeProof => "secp: invalid range proof",
             Error::PartialSigFailure => "secp: partial sig (aggsig) failure",
             Error::SigSubtractionFailure => "secp: subtraction (aggsig) did not result in any valid signatures",
+            Error::SysRngFailure => "secp: system generator failure",
+            Error::GenericError => "secp: generic error",
+            Error::RangeProofGeneration => "secp: unable to generate a range proof",
+            Error::NonceExportError => "secp: nonce export failure",
+            Error::InvalidParameters => "secp: invalid parameters",
+            Error::SerializationError => "secp: serialization error",
+            Error::AllocationError => "secp: instance allocation error",
+            Error::BrokenAggSigContext => "secp: AggSigContext is broken",
         }
     }
 }
 
 // Passthrough Debug to Display, since errors should be user-visible
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
     }
 }
 
-impl std::error::Error for Error {
-    fn description(&self) -> &str { self.as_str() }
-}
-
-
 /// The secp256k1 engine, used to execute all signature operations
 pub struct Secp256k1 {
     ctx: *mut ffi::Context,
-    caps: ContextFlag
+    caps: ContextFlag,
+    bulletproof_gen: Option<NonNull<ffi::BulletproofGenerators>>,
 }
 
-unsafe impl Send for Secp256k1 {}
-unsafe impl Sync for Secp256k1 {}
+// Note!!! Secp256k1 context is not safe to share between threads!
+// secp library thread safety tight to Secp256k1 context thread safety.
+//unsafe impl Send for Secp256k1 {}
+//unsafe impl Sync for Secp256k1 {}
+// Note: Clone for Secp256k1 is not enabled because we don't want share the conexts, as well as pass them between threads
 
 /// Flags used to determine the capabilities of a `Secp256k1` object;
 /// the more capabilities, the more expensive it is to create.
@@ -541,20 +782,6 @@ impl fmt::Display for ContextFlag {
     }
 }
 
-impl Clone for Secp256k1 {
-    fn clone(&self) -> Secp256k1 {
-        Secp256k1 {
-            ctx: unsafe { ffi::secp256k1_context_clone(self.ctx) },
-            caps: self.caps
-        }
-    }
-}
-
-impl PartialEq for Secp256k1 {
-    fn eq(&self, other: &Secp256k1) -> bool { self.caps == other.caps }
-}
-impl Eq for Secp256k1 { }
-
 impl fmt::Debug for Secp256k1 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         write!(f, "Secp256k1 {{ [private], caps: {:?} }}", self.caps)
@@ -563,6 +790,12 @@ impl fmt::Debug for Secp256k1 {
 
 impl Drop for Secp256k1 {
     fn drop(&mut self) {
+        if let Some(gen) = self.bulletproof_gen {
+            unsafe {
+                ffi::secp256k1_bulletproof_generators_destroy(self.ctx,
+                              gen.as_ptr());
+            }
+        }
         unsafe { ffi::secp256k1_context_destroy(self.ctx); }
     }
 }
@@ -570,12 +803,14 @@ impl Drop for Secp256k1 {
 impl Secp256k1 {
     /// Creates a new Secp256k1 context
     #[inline]
-    pub fn new() -> Secp256k1 {
+    pub fn new() -> Result<Secp256k1, Error> {
         Secp256k1::with_caps(ContextFlag::Full)
     }
 
     /// Creates a new Secp256k1 context with the specified capabilities
-    pub fn with_caps(caps: ContextFlag) -> Secp256k1 {
+    /// Note: randomize is not called because we don't need it for every case. Caller suppose to
+    ///   call randomize() for attack critical workflows
+    pub fn with_caps(caps: ContextFlag) -> Result<Secp256k1, Error> {
         let flag = match caps {
             ContextFlag::None => ffi::SECP256K1_START_NONE,
             ContextFlag::SignOnly => ffi::SECP256K1_START_SIGN,
@@ -584,40 +819,57 @@ impl Secp256k1 {
                 ffi::SECP256K1_START_SIGN | ffi::SECP256K1_START_VERIFY
             }
         };
-        Secp256k1 { ctx: unsafe { ffi::secp256k1_context_create(flag) }, caps: caps }
+
+        let ctx = unsafe { ffi::secp256k1_context_create(flag) };
+        if ctx.is_null() {
+            return Err(Error::GenericError);
+        }
+
+        let mut res = Secp256k1 {
+            ctx,
+            caps,
+            bulletproof_gen: None,
+        };
+
+        match caps {
+            ContextFlag::SignOnly | ContextFlag::Full | ContextFlag::Commit => res.randomize_priv(&mut SysRng)?,
+            _ => {},
+        }
+
+        Ok(res)
     }
 
     /// Creates a new Secp256k1 context with no capabilities (just de/serialization)
-    pub fn without_caps() -> Secp256k1 {
+    pub fn without_caps() -> Result<Secp256k1, Error> {
         Secp256k1::with_caps(ContextFlag::None)
     }
 
     /// (Re)randomizes the Secp256k1 context for cheap sidechannel resistence;
     /// see comment in libsecp256k1 commit d2275795f by Gregory Maxwell
-    pub fn randomize<R: Rng>(&mut self, rng: &mut R) {
+    fn randomize_priv<R: TryCryptoRng>(&mut self, rng: &mut R) -> Result<(), Error> {
         let mut seed = [0u8; 32];
-        rng.fill(&mut seed);
-        unsafe {
-            let err = ffi::secp256k1_context_randomize(self.ctx, seed.as_ptr());
-            // This function cannot fail; it has an error return for future-proofing.
-            // We do not expose this error since it is impossible to hit, and we have
-            // precedent for not exposing impossible errors (for example in
-            // `PublicKey::from_secret_key` where it is impossble to create an invalid
-            // secret key through the API.)
-            // However, if this DOES fail, the result is potentially weaker side-channel
-            // resistance, which is deadly and undetectable, so we take out the entire
-            // thread to be on the safe side.
-            assert!(err == 1);
+        rng.try_fill_bytes(&mut seed)
+            .map_err(|_| Error::SysRngFailure)?;
+
+        let res = unsafe {
+            ffi::secp256k1_context_randomize(self.ctx, seed.as_ptr())
+        };
+        seed.zeroize();
+
+        if res != 1 {
+            return Err(Error::GenericError);
         }
+
+        Ok(())
     }
 
     /// Generates a random keypair. Convenience function for `key::SecretKey::new`
     /// and `key::PublicKey::from_secret_key`; call those functions directly for
     /// batch key generation. Requires a signing-capable context.
     #[inline]
-    pub fn generate_keypair<R: Rng>(&self, rng: &mut R)
+    pub fn generate_keypair<R: TryCryptoRng>(&self, rng: &mut R)
                                    -> Result<(key::SecretKey, key::PublicKey), Error> {
-        let sk = key::SecretKey::new(self, rng);
+        let sk = key::SecretKey::new(self, rng)?;
         let pk = key::PublicKey::from_secret_key(self, &sk)?;
         Ok((sk, pk))
     }
@@ -625,20 +877,23 @@ impl Secp256k1 {
     /// Constructs a signature for `msg` using the secret key `sk` and RFC6979 nonce
     /// Requires a signing-capable context.
     pub fn sign(&self, msg: &Message, sk: &key::SecretKey)
-                -> Result<Signature, Error> {
+                -> Result<EcdsaSignature, Error> {
         if self.caps == ContextFlag::VerifyOnly || self.caps == ContextFlag::None {
             return Err(Error::IncapableContext);
         }
 
-        let mut ret = ffi::Signature::blank();
-        unsafe {
-            // We can assume the return value because it's not possible to construct
-            // an invalid signature from a valid `Message` and `SecretKey`
-            assert_eq!(ffi::secp256k1_ecdsa_sign(self.ctx, &mut ret, msg.as_ptr(),
+        let mut ret = EcdsaSignature::new();
+        let res = unsafe {
+            ffi::secp256k1_ecdsa_sign(self.ctx, ret.as_mut_ptr(), msg.as_ptr(),
                                                  sk.as_ptr(), ffi::secp256k1_nonce_function_rfc6979,
-                                                 ptr::null()), 1);
+                                                 ptr::null())
+        };
+        if res == 1 {
+            Ok(ret)
         }
-        Ok(Signature::from(ret))
+        else {
+            Err(Error::InvalidSecretKey)
+        }
     }
 
     /// Constructs a signature for `msg` using the secret key `sk` and RFC6979 nonce
@@ -649,15 +904,18 @@ impl Secp256k1 {
             return Err(Error::IncapableContext);
         }
 
-        let mut ret = ffi::RecoverableSignature::blank();
-        unsafe {
-            // We can assume the return value because it's not possible to construct
-            // an invalid signature from a valid `Message` and `SecretKey`
-            assert_eq!(ffi::secp256k1_ecdsa_sign_recoverable(self.ctx, &mut ret, msg.as_ptr(),
+        let mut ret = RecoverableSignature::new();
+        let ok = unsafe {
+            ffi::secp256k1_ecdsa_sign_recoverable(self.ctx, ret.as_mut_ptr(), msg.as_ptr(),
                                                              sk.as_ptr(), ffi::secp256k1_nonce_function_rfc6979,
-                                                             ptr::null()), 1);
+                                                             ptr::null())
+        };
+        if ok == 1 {
+            Ok(RecoverableSignature::from(ret))
         }
-        Ok(RecoverableSignature::from(ret))
+        else {
+            Err(Error::InvalidSecretKey)
+        }
     }
 
     /// Determines the public key for which `sig` is a valid signature for
@@ -676,7 +934,7 @@ impl Secp256k1 {
                 return Err(Error::InvalidSignature);
             }
         };
-        Ok(key::PublicKey::from(pk))
+        key::PublicKey::from_secp256k1_pubkey(self, pk)
     }
 
     /// Checks that `sig` is a valid ECDSA signature for `msg` using the public
@@ -685,28 +943,37 @@ impl Secp256k1 {
     /// which OpenSSL would verify but not libsecp256k1, or vice-versa. Requires a
     /// verify-capable context.
     #[inline]
-    pub fn verify(&self, msg: &Message, sig: &Signature, pk: &key::PublicKey) -> Result<(), Error> {
+    pub fn verify(&self, msg: &Message, sig: &EcdsaSignature, pk: &key::PublicKey) -> Result<(), Error> {
         if self.caps == ContextFlag::SignOnly || self.caps == ContextFlag::None {
             return Err(Error::IncapableContext);
         }
+        if !sig.is_valid(self) {
+            return Err(Error::InvalidSignature);
+        }
 
-        if !pk.is_valid() {
-            Err(Error::InvalidPublicKey)
-        } else if unsafe { ffi::secp256k1_ecdsa_verify(self.ctx, sig.as_ptr(), msg.as_ptr(),
-                                                       pk.as_ptr()) } == 0 {
-            Err(Error::IncorrectSignature)
-        } else {
+        if !pk.is_valid(&self) {
+            return Err(Error::InvalidPublicKey);
+        };
+
+        let ok = unsafe { ffi::secp256k1_ecdsa_verify(self.ctx, sig.as_ptr(), msg.as_ptr(),
+                                                       pk.as_ptr())
+        };
+
+        if ok == 1 {
             Ok(())
+        } else {
+            Err(Error::IncorrectSignature)
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use rand::{Rng, thread_rng};
+    use rand::TryRng;
+    use rand::rngs::SysRng;
     use crate::key::{SecretKey, PublicKey};
     use super::constants;
-    use super::{Secp256k1, Signature, RecoverableSignature, Message, RecoveryId, ContextFlag};
+    use super::{Secp256k1, EcdsaSignature, RecoverableSignature, Message, RecoveryId, ContextFlag};
     use super::Error::{InvalidMessage, InvalidPublicKey, IncorrectSignature, InvalidSignature,
                        IncapableContext};
 
@@ -725,21 +992,21 @@ mod tests {
 
     #[test]
     fn capabilities() {
-        let none = Secp256k1::with_caps(ContextFlag::None);
-        let sign = Secp256k1::with_caps(ContextFlag::SignOnly);
-        let vrfy = Secp256k1::with_caps(ContextFlag::VerifyOnly);
-        let full = Secp256k1::with_caps(ContextFlag::Full);
+        let none = Secp256k1::with_caps(ContextFlag::None).unwrap();
+        let sign = Secp256k1::with_caps(ContextFlag::SignOnly).unwrap();
+        let vrfy = Secp256k1::with_caps(ContextFlag::VerifyOnly).unwrap();
+        let full = Secp256k1::with_caps(ContextFlag::Full).unwrap();
 
         let mut msg = [0u8; 32];
-        thread_rng().fill(&mut msg);
+        SysRng.try_fill_bytes(&mut msg).unwrap();
         let msg = Message::from_slice(&msg).unwrap();
 
         // Try key generation
-        assert_eq!(none.generate_keypair(&mut thread_rng()), Err(IncapableContext));
-        assert_eq!(vrfy.generate_keypair(&mut thread_rng()), Err(IncapableContext));
-        assert!(sign.generate_keypair(&mut thread_rng()).is_ok());
-        assert!(full.generate_keypair(&mut thread_rng()).is_ok());
-        let (sk, pk) = full.generate_keypair(&mut thread_rng()).unwrap();
+        assert_eq!(none.generate_keypair(&mut SysRng), Err(IncapableContext));
+        assert_eq!(vrfy.generate_keypair(&mut SysRng), Err(IncapableContext));
+        assert!(sign.generate_keypair(&mut SysRng).is_ok());
+        assert!(full.generate_keypair(&mut SysRng).is_ok());
+        let (sk, pk) = full.generate_keypair(&mut SysRng).unwrap();
 
         // Try signing
         assert_eq!(none.sign(&msg, &sk), Err(IncapableContext));
@@ -772,7 +1039,7 @@ mod tests {
         assert_eq!(full.recover(&msg, &sigr), Ok(pk));
 
         // Check that we can produce keys from slices with no precomputation
-        let (pk_slice, sk_slice) = (&pk.serialize_vec(&none, true), &sk[..]);
+        let (pk_slice, sk_slice) = (&pk.serialize_vec(&none, true).unwrap(), &sk[..]);
         let new_pk = PublicKey::from_slice(&none, pk_slice).unwrap();
         let new_sk = SecretKey::from_slice(&none, sk_slice).unwrap();
         assert_eq!(sk, new_sk);
@@ -787,20 +1054,30 @@ mod tests {
 
     #[test]
     fn invalid_pubkey() {
-        let s = Secp256k1::new();
+        let s = Secp256k1::new().unwrap();
         let sig = RecoverableSignature::from_compact(&s, &[1; 64], RecoveryId(0)).unwrap();
-        let pk = PublicKey::new();
+        let pk = PublicKey::blank();
         let mut msg = [0u8; 32];
-        thread_rng().fill(&mut msg);
+        SysRng.try_fill_bytes(&mut msg).unwrap();
         let msg = Message::from_slice(&msg).unwrap();
 
-        assert_eq!(s.verify(&msg, &sig.to_standard(&s), &pk), Err(InvalidPublicKey));
+        assert_eq!(s.verify(&msg, &sig.to_standard(&s).unwrap(), &pk), Err(InvalidPublicKey));
+    }
+
+    #[test]
+    fn invalid_ecdsa_signature_encoding() {
+        let secp = Secp256k1::new().unwrap();
+        let sig = EcdsaSignature::new();
+        let (_, pk) = secp.generate_keypair(&mut SysRng).unwrap();
+        let msg = Message::from_slice(&[1u8; 32]).unwrap();
+
+        assert!(!sig.is_valid(&secp));
+        assert_eq!(secp.verify(&msg, &sig, &pk), Err(InvalidSignature));
     }
 
     #[test]
     fn sign() {
-        let mut s = Secp256k1::new();
-        s.randomize(&mut thread_rng());
+        let s = Secp256k1::new().unwrap();
         let one = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
 
@@ -822,30 +1099,29 @@ mod tests {
 
     #[test]
     fn signature_serialize_roundtrip() {
-        let mut s = Secp256k1::new();
-        s.randomize(&mut thread_rng());
+        let s = Secp256k1::new().unwrap();
 
         let mut msg = [0; 32];
         for _ in 0..100 {
-            thread_rng().fill(&mut msg);
+            SysRng.try_fill_bytes(&mut msg).unwrap();
             let msg = Message::from_slice(&msg).unwrap();
 
-            let (sk, _) = s.generate_keypair(&mut thread_rng()).unwrap();
+            let (sk, _) = s.generate_keypair(&mut SysRng).unwrap();
             let sig1 = s.sign(&msg, &sk).unwrap();
-            let der = sig1.serialize_der(&s);
-            let sig2 = Signature::from_der(&s, &der[..]).unwrap();
+            let der = sig1.serialize_der(&s).unwrap();
+            let sig2 = EcdsaSignature::from_der(&s, &der[..]).unwrap();
             assert_eq!(sig1, sig2);
 
-            let compact = sig1.serialize_compact(&s);
-            let sig2 = Signature::from_compact(&s, &compact[..]).unwrap();
+            let compact = sig1.serialize_compact(&s).unwrap();
+            let sig2 = EcdsaSignature::from_compact(&s, &compact[..]).unwrap();
             assert_eq!(sig1, sig2);
 
             round_trip_serde!(sig1);
 
-            assert!(Signature::from_compact(&s, &der[..]).is_err());
-            assert!(Signature::from_compact(&s, &compact[0..4]).is_err());
-            assert!(Signature::from_der(&s, &compact[..]).is_err());
-            assert!(Signature::from_der(&s, &der[0..4]).is_err());
+            assert!(EcdsaSignature::from_compact(&s, &der[..]).is_err());
+            assert!(EcdsaSignature::from_compact(&s, &compact[0..4]).is_err());
+            assert!(EcdsaSignature::from_der(&s, &compact[..]).is_err());
+            assert!(EcdsaSignature::from_der(&s, &der[0..4]).is_err());
          }
     }
 
@@ -853,9 +1129,9 @@ mod tests {
     fn signature_lax_der() {
         macro_rules! check_lax_sig(
             ($hex:expr) => ({
-                let secp = Secp256k1::without_caps();
+                let secp = Secp256k1::without_caps().unwrap();
                 let sig = hex!($hex);
-                assert!(Signature::from_der_lax(&secp, &sig[..]).is_ok());
+                assert!(EcdsaSignature::from_der_lax(&secp, &sig[..]).is_ok());
             })
         );
 
@@ -870,15 +1146,14 @@ mod tests {
 
     #[test]
     fn sign_and_verify() {
-        let mut s = Secp256k1::new();
-        s.randomize(&mut thread_rng());
+        let s = Secp256k1::new().unwrap();
 
         let mut msg = [0; 32];
         for _ in 0..100 {
-            thread_rng().fill(&mut msg);
+            SysRng.try_fill_bytes(&mut msg).unwrap();
             let msg = Message::from_slice(&msg).unwrap();
 
-            let (sk, pk) = s.generate_keypair(&mut thread_rng()).unwrap();
+            let (sk, pk) = s.generate_keypair(&mut SysRng).unwrap();
             let sig = s.sign(&msg, &sk).unwrap();
             assert_eq!(s.verify(&msg, &sig, &pk), Ok(()));
          }
@@ -886,8 +1161,7 @@ mod tests {
 
     #[test]
     fn sign_and_verify_extreme() {
-        let mut s = Secp256k1::new();
-        s.randomize(&mut thread_rng());
+        let s = Secp256k1::new().unwrap();
 
         // Wild keys: 1, CURVE_ORDER - 1
         // Wild msgs: 0, 1, CURVE_ORDER - 1, CURVE_ORDER
@@ -916,20 +1190,19 @@ mod tests {
 
     #[test]
     fn sign_and_verify_fail() {
-        let mut s = Secp256k1::new();
-        s.randomize(&mut thread_rng());
+        let s = Secp256k1::new().unwrap();
 
         let mut msg = [0u8; 32];
-        thread_rng().fill(&mut msg);
+        SysRng.try_fill_bytes(&mut msg).unwrap();
         let msg = Message::from_slice(&msg).unwrap();
 
-        let (sk, pk) = s.generate_keypair(&mut thread_rng()).unwrap();
+        let (sk, pk) = s.generate_keypair(&mut SysRng).unwrap();
 
         let sigr = s.sign_recoverable(&msg, &sk).unwrap();
-        let sig = sigr.to_standard(&s);
+        let sig = sigr.to_standard(&s).unwrap();
 
         let mut msg = [0u8; 32];
-        thread_rng().fill(&mut msg);
+        SysRng.try_fill_bytes(&mut msg).unwrap();
         let msg = Message::from_slice(&msg).unwrap();
         assert_eq!(s.verify(&msg, &sig, &pk), Err(IncorrectSignature));
 
@@ -939,14 +1212,13 @@ mod tests {
 
     #[test]
     fn sign_with_recovery() {
-        let mut s = Secp256k1::new();
-        s.randomize(&mut thread_rng());
+        let s = Secp256k1::new().unwrap();
 
         let mut msg = [0u8; 32];
-        thread_rng().fill(&mut msg);
+        SysRng.try_fill_bytes(&mut msg).unwrap();
         let msg = Message::from_slice(&msg).unwrap();
 
-        let (sk, pk) = s.generate_keypair(&mut thread_rng()).unwrap();
+        let (sk, pk) = s.generate_keypair(&mut SysRng).unwrap();
 
         let sig = s.sign_recoverable(&msg, &sk).unwrap();
 
@@ -955,8 +1227,7 @@ mod tests {
 
     #[test]
     fn bad_recovery() {
-        let mut s = Secp256k1::new();
-        s.randomize(&mut thread_rng());
+        let s = Secp256k1::new().unwrap();
 
         let msg = Message::from_slice(&[0x55; 32]).unwrap();
 
@@ -970,10 +1241,10 @@ mod tests {
 
     #[test]
     fn test_bad_slice() {
-        let s = Secp256k1::new();
-        assert_eq!(Signature::from_der(&s, &[0; constants::MAX_SIGNATURE_SIZE + 1]),
+        let s = Secp256k1::new().unwrap();
+        assert_eq!(EcdsaSignature::from_der(&s, &[0; constants::MAX_SIGNATURE_SIZE + 1]),
                    Err(InvalidSignature));
-        assert_eq!(Signature::from_der(&s, &[0; constants::MAX_SIGNATURE_SIZE]),
+        assert_eq!(EcdsaSignature::from_der(&s, &[0; constants::MAX_SIGNATURE_SIZE]),
                    Err(InvalidSignature));
 
         assert_eq!(Message::from_slice(&[0; constants::MESSAGE_SIZE - 1]),
@@ -984,8 +1255,16 @@ mod tests {
     }
 
     #[test]
+    fn test_from_der_rejects_invalid_scalars() {
+        let s = Secp256k1::new().unwrap();
+        let der_with_zero_r = [0x30, 0x06, 0x02, 0x01, 0x00, 0x02, 0x01, 0x01];
+
+        assert_eq!(EcdsaSignature::from_der(&s, &der_with_zero_r), Err(InvalidSignature));
+    }
+
+    #[test]
     fn test_debug_output() {
-        let s = Secp256k1::new();
+        let s = Secp256k1::new().unwrap();
         let sig = RecoverableSignature::from_compact(&s, &[
             0x66, 0x73, 0xff, 0xad, 0x21, 0x47, 0x74, 0x1f,
             0x04, 0x77, 0x2b, 0x6f, 0x92, 0x1f, 0x0b, 0xa6,
@@ -1007,7 +1286,7 @@ mod tests {
 
     #[test]
     fn test_recov_sig_serialize_compact() {
-        let s = Secp256k1::new();
+        let s = Secp256k1::new().unwrap();
 
         let recid_in = RecoveryId(1);
         let bytes_in = &[
@@ -1021,7 +1300,7 @@ mod tests {
             0x8d, 0x12, 0xee, 0xd0, 0x09, 0xb6, 0x8c, 0x89];
         let sig = RecoverableSignature::from_compact(
             &s, bytes_in, recid_in).unwrap();
-        let (recid_out, bytes_out) = sig.serialize_compact(&s);
+        let (recid_out, bytes_out) = sig.serialize_compact(&s).unwrap();
         assert_eq!(recid_in, recid_out);
         assert_eq!(&bytes_in[..], &bytes_out[..]);
     }
@@ -1049,22 +1328,23 @@ mod tests {
         let pk = hex!("031ee99d2b786ab3b0991325f2de8489246a6a3fdb700f6d0511b1d80cf5f4cd43");
         let msg = hex!("a4965ca63b7d8562736ceec36dfa5a11bf426eb65be8ea3f7a49ae363032da0d");
 
-        let secp = Secp256k1::new();
-        let mut sig = Signature::from_der(&secp, &sig[..]).unwrap();
+        let secp = Secp256k1::new().unwrap();
+        let mut sig = EcdsaSignature::from_der(&secp, &sig[..]).unwrap();
         let pk = PublicKey::from_slice(&secp, &pk[..]).unwrap();
         let msg = Message::from_slice(&msg[..]).unwrap();
 
         // without normalization we expect this will fail
         assert_eq!(secp.verify(&msg, &sig, &pk), Err(IncorrectSignature));
         // after normalization it should pass
-        sig.normalize_s(&secp);
+        sig.normalize_s(&secp).unwrap();
         assert_eq!(secp.verify(&msg, &sig, &pk), Ok(()));
     }
 }
 
 #[cfg(all(test, feature = "unstable"))]
 mod benches {
-    use rand::{Rng, thread_rng};
+    use rand::{Rng,TryCryptoRng};
+    use rand::rngs::SysRng;
     use test::{Bencher, black_box};
 
     use super::{Secp256k1, Message};
@@ -1076,7 +1356,7 @@ mod benches {
             fn next_u32(&mut self) -> u32 { self.0 += 1; self.0 }
         }
 
-        let s = Secp256k1::new();
+        let s = Secp256k1::new().unwrap();
         let mut r = CounterRng(0);
         bh.iter( || {
             let (sk, pk) = s.generate_keypair(&mut r).unwrap();
@@ -1087,11 +1367,11 @@ mod benches {
 
     #[bench]
     pub fn bench_sign(bh: &mut Bencher) {
-        let s = Secp256k1::new();
+        let s = Secp256k1::new().unwrap();
         let mut msg = [0u8; 32];
-        thread_rng().fill(&mut msg);
+        SysRng.try_fill_bytes(&mut msg).unwrap();
         let msg = Message::from_slice(&msg).unwrap();
-        let (sk, _) = s.generate_keypair(&mut thread_rng()).unwrap();
+        let (sk, _) = s.generate_keypair(&mut SysRng).unwrap();
 
         bh.iter(|| {
             let sig = s.sign(&msg, &sk).unwrap();
@@ -1101,11 +1381,11 @@ mod benches {
 
     #[bench]
     pub fn bench_verify(bh: &mut Bencher) {
-        let s = Secp256k1::new();
+        let s = Secp256k1::new().unwrap();
         let mut msg = [0u8; 32];
-        thread_rng().fill(&mut msg);
+        SysRng.try_fill_bytes(&mut msg).unwrap();
         let msg = Message::from_slice(&msg).unwrap();
-        let (sk, pk) = s.generate_keypair(&mut thread_rng()).unwrap();
+        let (sk, pk) = s.generate_keypair(&mut SysRng).unwrap();
         let sig = s.sign(&msg, &sk).unwrap();
 
         bh.iter(|| {
@@ -1116,11 +1396,11 @@ mod benches {
 
     #[bench]
     pub fn bench_recover(bh: &mut Bencher) {
-        let s = Secp256k1::new();
+        let s = Secp256k1::new().unwrap();
         let mut msg = [0u8; 32];
-        thread_rng().fill(&mut msg);
+        SysRng.try_fill_bytes(&mut msg).unwrap();
         let msg = Message::from_slice(&msg).unwrap();
-        let (sk, _) = s.generate_keypair(&mut thread_rng()).unwrap();
+        let (sk, _) = s.generate_keypair(&mut SysRng).unwrap();
         let sig = s.sign_recoverable(&msg, &sk).unwrap();
 
         bh.iter(|| {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -16,6 +16,21 @@
 // This is a macro that routinely comes in handy
 macro_rules! impl_array_newtype {
     ($thing:ident, $ty:ty, $len:expr) => {
+        impl_array_newtype!(@base $thing, $ty, $len);
+        impl_array_newtype!(@compare $thing, $ty, $len);
+        impl_array_newtype!(@serde $thing, $ty, $len);
+    };
+
+    ($thing:ident, $ty:ty, $len:expr, no_serde) => {
+        impl_array_newtype!(@base $thing, $ty, $len);
+        impl_array_newtype!(@compare $thing, $ty, $len);
+    };
+
+    ($thing:ident, $ty:ty, $len:expr, no_serde_no_comp) => {
+        impl_array_newtype!(@base $thing, $ty, $len);
+    };
+
+    (@base $thing:ident, $ty:ty, $len:expr) => {
         impl $thing {
             #[inline]
             /// Converts the object to a raw pointer for FFI interfacing
@@ -46,41 +61,10 @@ macro_rules! impl_array_newtype {
             }
         }
 
-        impl PartialEq for $thing {
-            #[inline]
-            fn eq(&self, other: &$thing) -> bool {
-                &self[..] == &other[..]
-            }
-        }
-
-        impl Eq for $thing {}
-
-        impl PartialOrd for $thing {
-            #[inline]
-            fn partial_cmp(&self, other: &$thing) -> Option<::core::cmp::Ordering> {
-                self[..].partial_cmp(&other[..])
-            }
-        }
-
-        impl Ord for $thing {
-            #[inline]
-            fn cmp(&self, other: &$thing) -> ::core::cmp::Ordering {
-                self[..].cmp(&other[..])
-            }
-        }
-
         impl Clone for $thing {
             #[inline]
             fn clone(&self) -> $thing {
-                unsafe {
-                    use std::ptr::copy_nonoverlapping;
-                    use std::mem;
-                    let mut ret = mem::MaybeUninit::<$thing>::uninit();
-                    copy_nonoverlapping(self.as_ptr(),
-                                       (*ret.as_mut_ptr()).as_mut_ptr(),
-                                       $len);
-                    ret.assume_init()
-                }
+                $thing(self.0.clone())
             }
         }
 
@@ -133,7 +117,9 @@ macro_rules! impl_array_newtype {
                 &dat[..]
             }
         }
+    };
 
+    (@compare $thing:ident, $ty:ty, $len:expr) => {
         impl ::std::hash::Hash for $thing {
           fn hash<H: ::std::hash::Hasher>(&self, state: &mut H) {
             state.write(&self.0)
@@ -143,6 +129,31 @@ macro_rules! impl_array_newtype {
           }
         }
 
+        impl PartialEq for $thing {
+            #[inline]
+            fn eq(&self, other: &$thing) -> bool {
+                &self[..] == &other[..]
+            }
+        }
+
+        impl Eq for $thing {}
+
+        impl PartialOrd for $thing {
+            #[inline]
+            fn partial_cmp(&self, other: &$thing) -> Option<::core::cmp::Ordering> {
+                self[..].partial_cmp(&other[..])
+            }
+        }
+
+        impl Ord for $thing {
+            #[inline]
+            fn cmp(&self, other: &$thing) -> ::core::cmp::Ordering {
+                self[..].cmp(&other[..])
+            }
+        }
+    };
+
+    (@serde $thing:ident, $ty:ty, $len:expr) => {
         impl<'de> ::serde::Deserialize<'de> for $thing {
             fn deserialize<D>(d: D) -> Result<$thing, D::Error>
                 where D: ::serde::Deserializer<'de>
@@ -194,7 +205,7 @@ macro_rules! impl_array_newtype {
                 (&self.0[..]).serialize(s)
             }
         }
-    }
+    };
 }
 
 macro_rules! impl_pretty_debug {
@@ -225,7 +236,7 @@ macro_rules! impl_raw_debug {
 }
 
 macro_rules! map_vec {
-  ($thing:expr, $mapfn:expr ) => {
+  ($thing:ident, $mapfn:expr ) => {
     $thing.iter()
       .map($mapfn)
       .collect::<Vec<_>>()
@@ -244,6 +255,6 @@ macro_rules! round_trip_serde (
         }
         let mut deserializer = crate::json::de::Deserializer::from_slice(&encoded);
         let decoded = ::serde::Deserialize::deserialize(&mut deserializer);
-        assert_eq!(Some(start), decoded.ok());
+        assert!(Some(start) == decoded.ok());
     })
 );

--- a/src/pedersen.rs
+++ b/src/pedersen.rs
@@ -17,62 +17,30 @@
 //! # Pedersen commitments and related range proofs
 
 use libc::size_t;
-use std::cmp::min;
 use std::fmt;
 use std::ptr;
-use std::sync::OnceLock;
+use std::ptr::NonNull;
 use std::u64;
 
 use crate::ContextFlag;
-use crate::Error::{self, InvalidPublicKey, InvalidCommit};
+use crate::Error;
 use crate::Secp256k1;
 
-use super::{Message, Signature};
-use crate::aggsig::ZERO_256;
+use super::{EcdsaSignature, Message};
 use crate::constants;
 use crate::ffi;
 use crate::key::{self, PublicKey, SecretKey};
-use rand::{thread_rng, Rng};
+use rand::TryRng;
+use rand::rngs::SysRng;
 use serde::{de, ser};
+use zeroize::Zeroize;
 
 const MAX_WIDTH: usize = 1 << 20;
 const SCRATCH_SPACE_SIZE: size_t = 256 * MAX_WIDTH;
 const MAX_GENERATORS: size_t = 256;
 
-/// Shared Bullet Proof Generators (avoid recreating every time)
-struct SharedGenerators(*mut ffi::BulletproofGenerators);
-unsafe impl Send for SharedGenerators {}
-unsafe impl Sync for SharedGenerators {}
-
-static SHARED_BULLETGENERATORS: OnceLock<SharedGenerators> = OnceLock::new();
-
-fn shared_generators(ctx: *mut ffi::Context) -> *mut ffi::BulletproofGenerators {
-	SHARED_BULLETGENERATORS
-		.get_or_init(|| unsafe {
-			SharedGenerators(
-				ffi::secp256k1_bulletproof_generators_create(
-					ctx,
-					constants::GENERATOR_G.as_ptr(),
-					MAX_GENERATORS,
-				)
-			)
-		})
-		.0
-}
-
-/// underling lib's representation of a commit, which is now a full 64 bytes
-pub struct CommitmentInternal(pub [u8; constants::PEDERSEN_COMMITMENT_SIZE_INTERNAL]);
-impl Copy for CommitmentInternal {}
-impl_array_newtype!(CommitmentInternal, u8, constants::PEDERSEN_COMMITMENT_SIZE_INTERNAL);
-impl_pretty_debug!(CommitmentInternal);
-
-
-impl CommitmentInternal {
-	/// Uninitialized commitment, use with caution
-	pub unsafe fn blank() -> CommitmentInternal {
-		CommitmentInternal([0; constants::PEDERSEN_COMMITMENT_SIZE_INTERNAL])
-	}
-}
+/// Underlying lib's opaque internal representation of a commitment.
+type CommitmentInternal = ffi::PedersenCommitment;
 
 /// A Pedersen commitment
 pub struct Commitment(pub [u8; constants::PEDERSEN_COMMITMENT_SIZE]);
@@ -81,29 +49,36 @@ impl_array_newtype!(Commitment, u8, constants::PEDERSEN_COMMITMENT_SIZE);
 impl_pretty_debug!(Commitment);
 
 impl Commitment {
-	/// Builds a Hash from a byte vector. If the vector is too short, it will be
-	/// completed by zeroes. If it's too long, it will be truncated.
-	pub fn from_vec(v: Vec<u8>) -> Commitment {
+	/// Building Commit data from the row data. Start enforcing the data size.
+	/// We don't truncate data or pad with zeroes
+	pub fn from_vec(v: Vec<u8>) -> Result<Commitment, Error> {
+		if v.len() != constants::PEDERSEN_COMMITMENT_SIZE {
+			return Err(Error::InvalidParameters);
+		}
 		let mut h = [0; constants::PEDERSEN_COMMITMENT_SIZE];
-		for i in 0..min(v.len(), constants::PEDERSEN_COMMITMENT_SIZE) {
+		for i in 0..constants::PEDERSEN_COMMITMENT_SIZE {
 			h[i] = v[i];
 		}
-		Commitment(h)
+		Ok(Commitment(h))
 	}
 
 	/// Uninitialized commitment, use with caution
-	unsafe fn blank() -> Commitment {
+	fn blank() -> Commitment {
 		Commitment([0; constants::PEDERSEN_COMMITMENT_SIZE])
 	}
 
 	/// Creates from a pubkey
 	pub fn from_pubkey(secp: &Secp256k1, pk: &key::PublicKey) -> Result<Self, Error> {
+		if !pk.is_valid(secp) {
+			return Err(Error::InvalidPublicKey);
+		}
+
 		unsafe {
-			let mut commit_i = [0; constants::PEDERSEN_COMMITMENT_SIZE_INTERNAL];
-			if ffi::secp256k1_pubkey_to_pedersen_commitment(secp.ctx, commit_i.as_mut_ptr(), &pk.0 as *const _) == 1 {
+			let mut commit_i = CommitmentInternal::blank();
+			if ffi::secp256k1_pubkey_to_pedersen_commitment(secp.ctx, &mut commit_i, &pk.0 as *const _) == 1 {
 				Ok(secp.commit_ser(commit_i)?)
 			} else {
-				Err(InvalidCommit)
+				Err(Error::InvalidCommit)
 			}
 		}
 	}
@@ -113,10 +88,10 @@ impl Commitment {
 		let mut pk = ffi::PublicKey::blank();
 		unsafe {
 			let commit = secp.commit_parse(self.0.clone())?;
-			if ffi::secp256k1_pedersen_commitment_to_pubkey(secp.ctx, &mut pk, commit.as_ptr()) == 1 {
-				Ok(key::PublicKey::from_secp256k1_pubkey(pk))
+			if ffi::secp256k1_pedersen_commitment_to_pubkey(secp.ctx, &mut pk, &commit) == 1 {
+				Ok(PublicKey::from_secp256k1_pubkey(secp, pk)?)
 			} else {
-				Err(InvalidPublicKey)
+				Err(Error::InvalidPublicKey)
 			}
 		}
 	}
@@ -133,8 +108,9 @@ pub struct RangeProof {
 }
 
 impl PartialEq for RangeProof {
+	// Note, in case of malformed RangeProof, equal will return false
 	fn eq(&self, other: &Self) -> bool {
-		self.proof.as_ref() == other.proof.as_ref()
+		self.plen <= constants::MAX_PROOF_SIZE && self.plen == other.plen && self.proof[..self.plen] == other.proof[..self.plen]
 	}
 }
 
@@ -143,6 +119,9 @@ impl ser::Serialize for RangeProof {
 	where
 		S: ser::Serializer,
 	{
+		if self.plen > constants::MAX_PROOF_SIZE {
+			return Err( serde::ser::Error::custom(format!("Invalid RangeProof size {}", self.plen)) );
+		}
 		(&self.proof[..self.plen]).serialize(s)
 	}
 }
@@ -164,6 +143,9 @@ impl<'di> de::Visitor<'di> for Visitor {
 		let mut ret: [u8; constants::MAX_PROOF_SIZE] = [0u8; constants::MAX_PROOF_SIZE];
 		let mut i = 0;
 		while let Some(val) = v.next_element()? {
+			if i>=constants::MAX_PROOF_SIZE {
+				return Err(::serde::de::Error::custom("RangeProof invalid size (too large)"));
+			}
 			ret[i] = val;
 			i += 1;
 		}
@@ -184,30 +166,35 @@ impl<'de> de::Deserialize<'de> for RangeProof {
 	}
 }
 
+// Note: We understand that this exposing the proof opaque internals. But existing code is
+//     already depends on that and using it for hashing and storage.
 impl AsRef<[u8]> for RangeProof {
 	fn as_ref(&self) -> &[u8] {
 		&self.proof[..self.plen as usize]
 	}
 }
 
-// This is a macro that check zero public key
-macro_rules! is_zero_pubkey {
-	(retnone => $e:expr) => {
+
+// This is a macro that check zero or invalid public key
+// Note, if pub key is invalid, no error is generated, it is expected
+//    this pub key will be ignored or used as a buffer for result.
+macro_rules! is_valid_pubkey {
+	(retnone => $secp:expr, $e:expr) => {
 		match $e {
 			Some(n) => {
-				if (n.0).0.starts_with(&ZERO_256) {
-					return None;
-					}
-				n.as_mut_ptr()
+				if !n.is_valid($secp) {
+					return Err(Error::InvalidPublicKey);
 				}
+				n.as_mut_ptr()
+			},
 			None => ptr::null_mut(),
-			}
+		}
 	};
 	(ignore => $e:expr) => {
 		match $e {
 			Some(n) => n.as_mut_ptr(),
 			None => ptr::null_mut(),
-			}
+		}
 	};
 }
 
@@ -220,12 +207,24 @@ impl RangeProof {
 		}
 	}
 	/// The range proof as a byte slice.
-	pub fn bytes(&self) -> &[u8] {
-		&self.proof[..self.plen as usize]
+	pub fn bytes(&self) -> Result<&[u8], Error> {
+		if self.plen > constants::MAX_PROOF_SIZE {
+			return Err(Error::InvalidRangeProof);
+		}
+		Ok(&self.proof[..self.plen])
 	}
 	/// Length of the range proof in bytes.
-	pub fn len(&self) -> usize {
-		self.plen
+	pub fn len(&self) -> Result<usize, Error> {
+		if self.plen > constants::MAX_PROOF_SIZE {
+			return Err(Error::InvalidRangeProof);
+		}
+		Ok(self.plen)
+	}
+
+	/// Validate is RangeProof data with expected parameters.
+	/// Note: This method does not verify proof structure or cryptographic validity.
+	pub fn is_valid(&self) -> bool {
+		self.plen <= constants::MAX_PROOF_SIZE
 	}
 }
 
@@ -242,12 +241,16 @@ impl ProofMessage {
 	}
 
 	/// Creates a message from a byte slice.
-	pub fn from_bytes(array: &[u8]) -> ProofMessage {
+	pub fn from_bytes(array: &[u8]) -> Result<ProofMessage, Error> {
+		if array.len() > constants::PROOF_MSG_SIZE {
+			return Err(Error::InvalidParameters);
+		}
+
 		let mut msg = vec![];
 		for &value in array {
 			msg.push(value);
 		}
-		ProofMessage(msg)
+		Ok(ProofMessage(msg))
 	}
 
 	/// Converts the message to a byte slice.
@@ -269,17 +272,26 @@ impl ProofMessage {
 	/// Message in the range proof is the first len bytes of the fixed PROOF_MSG_SIZE.
 	/// We can truncate it to the correct size if we know how many bytes we care about.
 	/// This probably implies the message will take a known format.
-	pub fn truncate(&mut self, len: usize) {
-		self.0.truncate(len)
+	pub fn truncate(&mut self, len: usize) -> Result<(), Error> {
+		if len>constants::PROOF_MSG_SIZE {
+			return Err(Error::InvalidParameters);
+		}
+
+		Ok(self.0.truncate(len))
 	}
 
 	/// Push a byte onto the message
-	pub fn push(&mut self, value: u8) {
+	pub fn push(&mut self, value: u8) -> Result<(), Error> {
+		if self.0.len()>=constants::PROOF_MSG_SIZE {
+			return Err(Error::InvalidParameters);
+		}
 		self.0.push(value);
+		Ok(())
 	}
 }
 
 impl ::std::cmp::PartialEq for ProofMessage {
+	// Note: constant-time equality guarantee if not required for ProofMessage
 	fn eq(&self, other: &ProofMessage) -> bool {
 		self.0[..] == other.0[..]
 	}
@@ -288,11 +300,7 @@ impl ::std::cmp::Eq for ProofMessage {}
 
 impl ::std::fmt::Debug for ProofMessage {
 	fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-		write!(f, "{}(", stringify!(ProofMessage))?;
-		for i in self.0.iter().cloned() {
-			write!(f, "{:02x}", i)?;
-		}
-		write!(f, ")")
+		write!(f, "ProofMessage(*******)")
 	}
 }
 
@@ -330,11 +338,16 @@ pub struct ProofInfo {
 
 impl ::std::fmt::Debug for RangeProof {
 	fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-		write!(f, "{}(", stringify!(RangeProof))?;
-		for i in self.proof[..self.plen].iter().cloned() {
-			write!(f, "{:02x}", i)?;
+		if self.is_valid() {
+			write!(f, "{}(", stringify!(RangeProof))?;
+			for i in self.proof[..self.plen].iter().cloned() {
+				write!(f, "{:02x}", i)?;
+			}
+			write!(f, ")[{}]", self.plen)
 		}
-		write!(f, ")[{}]", self.plen)
+		else {
+			write!(f, stringify!("RangeProof(Invalid)"))
+		}
 	}
 }
 
@@ -343,14 +356,14 @@ impl Secp256k1 {
 	pub fn verify_from_commit(
 		&self,
 		msg: &Message,
-		sig: &Signature,
+		sig: &EcdsaSignature,
 		commit: &Commitment,
 	) -> Result<(), Error> {
 		if self.caps != ContextFlag::Commit {
 			return Err(Error::IncapableContext);
 		}
 
-		let pubkey = commit.to_pubkey(&self).unwrap();
+		let pubkey = commit.to_pubkey(&self)?;
 
 		let result = self.verify(msg, sig, &pubkey);
 		match result {
@@ -366,31 +379,46 @@ impl Secp256k1 {
 			let mut c_out = CommitmentInternal::blank();
 			let ret = ffi::secp256k1_pedersen_commitment_parse(
 				self.ctx,
-				c_out.as_mut_ptr(),
+				&mut c_out,
 				c_in.as_ptr(),
 			);
 			if ret == 1 {
 				Ok(c_out)
 			} else {
-				Err(InvalidCommit)
+				Err(Error::InvalidCommit)
 			}
 		};
 		c_out
 	}
 
 	/// Parse a commit into an internal representation
-	fn commit_ser(&self, c_in: [u8;constants::PEDERSEN_COMMITMENT_SIZE_INTERNAL])
+	fn commit_ser(&self, c_in: CommitmentInternal)
 	-> Result<Commitment, Error> {
 		let c_out = unsafe {
 			let mut c_out = Commitment::blank();
-			ffi:: secp256k1_pedersen_commitment_serialize(
+			let ok = ffi:: secp256k1_pedersen_commitment_serialize(
 				self.ctx,
 				c_out.as_mut_ptr(),
-				c_in.as_ptr(),
+				&c_in,
 			);
-			c_out
+			if ok!=1 {
+				Err(Error::SerializationError)
+			}
+			else {
+				Ok(c_out)
+			}
 		};
-		Ok(c_out)
+		c_out
+	}
+
+	/// Validates that a serialized Pedersen commitment is parseable and canonical.
+	pub fn validate_commitment(&self, commit: &Commitment) -> Result<(), Error> {
+		let commit_i = self.commit_parse(commit.0)?;
+		if self.commit_ser(commit_i)? == *commit {
+			Ok(())
+		} else {
+			Err(Error::InvalidCommit)
+		}
 	}
 
 	/// Creates a pedersen commitment from a value and a blinding factor
@@ -398,18 +426,24 @@ impl Secp256k1 {
 		if self.caps != ContextFlag::Commit {
 			return Err(Error::IncapableContext);
 		}
-		let mut commit_i = [0; constants::PEDERSEN_COMMITMENT_SIZE_INTERNAL];
-		unsafe {
+		let mut commit_i = CommitmentInternal::blank();
+		let ok = unsafe {
 			ffi::secp256k1_pedersen_commit(
 				self.ctx,
-				commit_i.as_mut_ptr(),
+				&mut commit_i,
 				blind.as_ptr(),
 				value,
-				constants::GENERATOR_H.as_ptr(),
-				constants::GENERATOR_G.as_ptr(),
+				&ffi::Generator(constants::GENERATOR_H),
+				&ffi::Generator(constants::GENERATOR_G),
 			)
 		};
-		Ok(self.commit_ser(commit_i)?)
+
+		if ok != 1 {
+			Err(Error::InvalidCommit)
+		}
+		else {
+			Ok(self.commit_ser(commit_i)?)
+		}
 	}
 
 	/// Creates a pedersen commitment from a two blinding factors
@@ -417,18 +451,23 @@ impl Secp256k1 {
 		if self.caps != ContextFlag::Commit {
 			return Err(Error::IncapableContext);
 		}
-		let mut commit_i = [0; constants::PEDERSEN_COMMITMENT_SIZE_INTERNAL];
-		unsafe {
+		let mut commit_i = CommitmentInternal::blank();
+		let ok = unsafe {
 			ffi::secp256k1_pedersen_blind_commit(
 				self.ctx,
-				commit_i.as_mut_ptr(),
+				&mut commit_i,
 				blind.as_ptr(),
 				value.as_ptr(),
-				constants::GENERATOR_H.as_ptr(),
-				constants::GENERATOR_G.as_ptr(),
+				&ffi::Generator(constants::GENERATOR_H),
+				&ffi::Generator(constants::GENERATOR_G),
 			)
 		};
-		Ok(self.commit_ser(commit_i)?)
+		if ok != 1 {
+			Err(Error::InvalidCommit)
+		}
+		else {
+			Ok(self.commit_ser(commit_i)?)
+		}
 	}
 
 	/// Convenience method to Create a pedersen commitment only from a value,
@@ -437,46 +476,47 @@ impl Secp256k1 {
 		if self.caps != ContextFlag::Commit {
 			return Err(Error::IncapableContext);
 		}
-		let mut commit_i = [0; constants::PEDERSEN_COMMITMENT_SIZE_INTERNAL];
+		let mut commit_i = CommitmentInternal::blank();
 		let zblind = [0u8; 32];
 
-		unsafe {
+		let ok = unsafe {
 			ffi::secp256k1_pedersen_commit(
 				self.ctx,
-				commit_i.as_mut_ptr(),
+				&mut commit_i,
 				zblind.as_ptr(),
 				value,
-				constants::GENERATOR_H.as_ptr(),
-				constants::GENERATOR_G.as_ptr(),
+				&ffi::Generator(constants::GENERATOR_H),
+				&ffi::Generator(constants::GENERATOR_G),
 			)
 		};
-		Ok(self.commit_ser(commit_i)?)
+		if ok != 1 {
+			Err(Error::InvalidCommit)
+		}
+		else {
+			Ok(self.commit_ser(commit_i)?)
+		}
 	}
 
 	/// Taking vectors of positive and negative commitments as well as an
 	/// expected excess, verifies that it all sums to zero.
-	pub fn verify_commit_sum(&self, positive: Vec<Commitment>, negative: Vec<Commitment>) -> bool {
+	/// Note, false can be returned in case of some internal error. False negative is accepted for our usage.
+	pub fn verify_commit_sum(&self, positive: Vec<Commitment>, negative: Vec<Commitment>) -> Result<bool, Error> {
 		let pos = map_vec!(positive, |p| self.commit_parse(p.0));
-		let pos = match pos.into_iter().collect::<Result<Vec<_>, _>>() {
-			Ok(pos) => pos,
-			Err(_) => return false,
-		};
+		let pos = pos.into_iter().collect::<Result<Vec<_>, _>>()?;
 		let neg = map_vec!(negative, |n| self.commit_parse(n.0));
-		let neg = match neg.into_iter().collect::<Result<Vec<_>, _>>() {
-			Ok(neg) => neg,
-			Err(_) => return false,
-		};
-		let pos = map_vec!(pos, |p| p.0.as_ptr());
-		let neg = map_vec!(neg, |n| n.0.as_ptr());
-		unsafe {
+		let neg = neg.into_iter().collect::<Result<Vec<_>, _>>()?;
+		let pos = map_vec!(pos, |p| p as *const _);
+		let neg = map_vec!(neg, |n| n as *const _);
+		let res = unsafe {
 			ffi::secp256k1_pedersen_verify_tally(
 				self.ctx,
 				pos.as_ptr(),
 				pos.len() as size_t,
 				neg.as_ptr(),
 				neg.len() as size_t,
-			) == 1
-		}
+			)
+		};
+		Ok(res == 1)
 	}
 
 	/// Computes the sum of multiple positive and negative pedersen commitments.
@@ -491,13 +531,13 @@ impl Secp256k1 {
 		let neg = map_vec!(negative, |n| self.commit_parse(n.0))
 			.into_iter()
 			.collect::<Result<Vec<_>, _>>()?;
-		let pos = map_vec!(pos, |p| p.0.as_ptr());
-		let neg = map_vec!(neg, |n| n.0.as_ptr());
-		let mut ret_i = unsafe { CommitmentInternal::blank() };
+		let pos = map_vec!(pos, |p| p as *const _);
+		let neg = map_vec!(neg, |n| n as *const _);
+		let mut ret_i = CommitmentInternal::blank();
 		let err = unsafe {
 			ffi::secp256k1_pedersen_commit_sum(
 				self.ctx,
-				ret_i.as_mut_ptr(),
+				&mut ret_i,
 				pos.as_ptr(),
 				pos.len() as size_t,
 				neg.as_ptr(),
@@ -505,7 +545,7 @@ impl Secp256k1 {
 			)
 		};
 		if err == 1 {
-			Ok(self.commit_ser(ret_i.0)?)
+			Ok(self.commit_ser(ret_i)?)
 		} else {
 			Err(Error::IncorrectCommitSum)
 		}
@@ -517,58 +557,80 @@ impl Secp256k1 {
 		positive: Vec<SecretKey>,
 		negative: Vec<SecretKey>,
 	) -> Result<SecretKey, Error> {
+		// Rejecting empty inputs because that will result as empty result. Empty secret is not valid.
+		if positive.is_empty() && negative.is_empty() {
+			return Err(Error::InvalidParameters);
+		}
 		let mut neg = map_vec!(negative, |n| n.as_ptr());
 		let mut all = map_vec!(positive, |p| p.as_ptr());
 		all.append(&mut neg);
 		let mut ret: [u8; 32] = [0u8; 32];
-		unsafe {
-			assert_eq!(
-				ffi::secp256k1_pedersen_blind_sum(
-					self.ctx,
-					ret.as_mut_ptr(),
-					all.as_ptr(),
-					all.len() as size_t,
-					positive.len() as size_t,
-				),
-				1
-			);
+		let ok = unsafe {
+			ffi::secp256k1_pedersen_blind_sum(
+				self.ctx,
+				ret.as_mut_ptr(),
+				all.as_ptr(),
+				all.len() as size_t,
+				positive.len() as size_t,
+			)
+		};
+		// from_slice distinguishes a valid zero result from malformed output.
+		if ok == 1 {
+			let res = SecretKey::from_slice(self, &ret);
+			ret.zeroize();
+			res
 		}
-		// secp256k1 should never return an invalid private
-		SecretKey::from_slice(self, &ret)
+		else {
+			ret.zeroize();
+			Err(Error::InvalidSecretKey)
+		}
 	}
 
 	/// Compute a blinding factor using a switch commitment
+	/// Note, in case of error, failure might be retryable with different values.
 	pub fn blind_switch(&self, value: u64, blind: SecretKey) -> Result<SecretKey, Error> {
 		if self.caps != ContextFlag::Commit {
 			return Err(Error::IncapableContext);
 		}
 		let mut ret: [u8; 32] = [0u8; 32];
-		unsafe {
-			assert_eq!(
-				ffi::secp256k1_blind_switch(
-					self.ctx,
-					ret.as_mut_ptr(),
-					blind.as_ptr(),
-					value,
-					constants::GENERATOR_H.as_ptr(),
-					constants::GENERATOR_G.as_ptr(),
-					constants::GENERATOR_PUB_J_RAW.as_ptr(),
-				),
-				1
+		// Note: GENERATOR_PUB_J_RAW is expected to stay on the Rust side of the code.
+		let ok = unsafe {
+			ffi::secp256k1_blind_switch(
+				self.ctx,
+				ret.as_mut_ptr(),
+				blind.as_ptr(),
+				value,
+				&ffi::Generator(constants::GENERATOR_H),
+				&ffi::Generator(constants::GENERATOR_G),
+				&ffi::PublicKey(constants::GENERATOR_PUB_J_RAW),
 			)
+		};
+		if ok == 1 {
+			let res = SecretKey::from_slice(self, &ret);
+			ret.zeroize();
+			res
 		}
-		SecretKey::from_slice(self, &ret)
+		else {
+			ret.zeroize();
+			Err(Error::GenericError)
+		}
 	}
 
 	/// Convenience function for generating a random nonce for a range proof.
 	/// We will need the nonce later if we want to rewind the range proof.
-	pub fn nonce(&self) -> [u8; 32] {
-		thread_rng().gen::<[u8; 32]>()
+	pub fn nonce(&self) -> Result<[u8; 32], Error> {
+		let mut bytes = [0u8; 32];
+		SysRng.try_fill_bytes(&mut bytes)
+			.map_err(|_| Error::SysRngFailure)?;
+		Ok(bytes)
 	}
 
 	/// Produces a range proof for the provided value, using min and max
 	/// bounds, relying
 	/// on the blinding factor and commitment.
+	/// Note: Error RangeProofGeneration generated in case of invalid values and also rare case when
+	/// 		retry might help if blind factor wil be regenerated.
+	#[cfg(not(feature = "bullet-proof-sizing"))]
 	pub fn range_proof(
 		&self,
 		min: u64,
@@ -576,8 +638,11 @@ impl Secp256k1 {
 		blind: SecretKey,
 		commit: Commitment,
 		message: ProofMessage,
-	) -> RangeProof {
-		let mut retried = false;
+	) -> Result<RangeProof, Error> {
+		if self.caps == ContextFlag::None || self.caps == ContextFlag::SignOnly || self.caps == ContextFlag::VerifyOnly {
+			return Err(Error::IncapableContext);
+		}
+
 		let mut proof = [0; constants::MAX_PROOF_SIZE];
 		let mut plen = constants::MAX_PROOF_SIZE as size_t;
 
@@ -589,53 +654,64 @@ impl Secp256k1 {
 
 		let extra_commit = [0u8; 33];
 
-		let commit = self.commit_parse(commit.0).unwrap();
+		let commit = self.commit_parse(commit.0)?;
 
-		// TODO - confirm this reworked retry logic works as expected
-		// pretty sure the original approach retried on success (so twice in total)
-		// and just kept looping forever on error
-		loop {
-			let success = unsafe {
-				// because: "This can randomly fail with probability around one in 2^100.
-				// If this happens, buy a lottery ticket and retry."
-				ffi::secp256k1_rangeproof_sign(
-					self.ctx,
-					proof.as_mut_ptr(),
-					&mut plen,
-					min,
-					commit.as_ptr(),
-					blind.as_ptr(),
-					nonce.as_ptr(),
-					0,
-					64,
-					value,
-					message.as_ptr(),
-					message.len(),
-					extra_commit.as_ptr(),
-					0 as size_t,
-					constants::GENERATOR_H.as_ptr(),
-				) == 1
-			};
-			// break out of the loop immediately on success or
-			// or on the 2nd attempt if we retried
-			if success || retried {
-				break;
+		let msg_ptr = if message.len() == 0 {
+			ptr::null()
+		} else {
+			message.as_ptr()
+		};
+
+		let ok = unsafe {
+			// because: "This can randomly fail with probability around one in 2^100.
+			// If this happens, buy a lottery ticket and retry."
+			ffi::secp256k1_rangeproof_sign(
+				self.ctx,
+				proof.as_mut_ptr(),
+				&mut plen,
+				min,
+				&commit,
+				blind.as_ptr(),
+				nonce.as_ptr(),
+				0,
+				64,
+				value,
+				msg_ptr,
+				message.len(),
+				extra_commit.as_ptr(),
+				0 as size_t,
+				&ffi::Generator(constants::GENERATOR_H),
+			)
+		};
+
+		if ok == 1 {
+			if plen <= constants::MAX_PROOF_SIZE {
+				return Ok(RangeProof {
+					proof: proof,
+					plen: plen as usize,
+				});
 			} else {
-				retried = true;
+				return Err(Error::RangeProofGeneration)
 			}
 		}
-		RangeProof {
-			proof: proof,
-			plen: plen as usize,
-		}
+
+		Err(Error::RangeProofGeneration)
 	}
 
 	/// Verify a proof that a committed value is within a range.
+	#[cfg(not(feature = "bullet-proof-sizing"))]
 	pub fn verify_range_proof(
 		&self,
 		commit: Commitment,
 		proof: RangeProof,
 	) -> Result<ProofRange, Error> {
+		if !proof.is_valid() {
+			return Err(Error::InvalidRangeProof)
+		}
+		if self.caps == ContextFlag::None || self.caps == ContextFlag::SignOnly {
+			return Err(Error::IncapableContext);
+		}
+
 		let mut min: u64 = 0;
 		let mut max: u64 = 0;
 
@@ -648,12 +724,12 @@ impl Secp256k1 {
 				self.ctx,
 				&mut min,
 				&mut max,
-				commit.as_ptr(),
+				&commit,
 				proof.proof.as_ptr(),
 				proof.plen as size_t,
 				extra_commit.as_ptr(),
 				0 as size_t,
-				constants::GENERATOR_H.as_ptr(),
+				&ffi::Generator(constants::GENERATOR_H),
 			) == 1
 		};
 
@@ -666,14 +742,29 @@ impl Secp256k1 {
 
 	/// Verify a range proof and rewind the proof to recover information
 	/// sent by its author.
+	/// Note: resulting ProofInfo success flag can be false because of internal errors.
+	///     False negative result is acceptable
+	/// Note: ProofInfo with a negative success flag might contain other fields in any state
+	///     since caller is not expecting to use them
+	#[cfg(not(feature = "bullet-proof-sizing"))]
 	pub fn rewind_range_proof(
 		&self,
 		commit: Commitment,
 		proof: RangeProof,
 		nonce: SecretKey,
-	) -> ProofInfo {
+	) -> Result<ProofInfo, Error> {
+		if !proof.is_valid() {
+			return Err(Error::InvalidRangeProof)
+		}
+		if self.caps == ContextFlag::None || self.caps == ContextFlag::SignOnly || self.caps == ContextFlag::VerifyOnly {
+			return Err(Error::IncapableContext);
+		}
+
 		let mut value: u64 = 0;
+		// Note: recovered blind factor will be discarded intentionally
 		let mut blind: [u8; 32] = [0u8; 32];
+		// Note: message is intentionally limited by 2048 even rangeproof support the bigger buffer.
+		//    Larger message will be truncated to fit this buffer
 		let mut message: [u8; constants::PROOF_MSG_SIZE] = [0u8; constants::PROOF_MSG_SIZE];
 		let mut mlen: usize = constants::PROOF_MSG_SIZE;
 		let mut min: u64 = 0;
@@ -681,7 +772,7 @@ impl Secp256k1 {
 
 		let extra_commit = [0u8; 33];
 
-		let commit = self.commit_parse(commit.0).unwrap();
+		let commit = self.commit_parse(commit.0)?;
 
 		let success = unsafe {
 			ffi::secp256k1_rangeproof_rewind(
@@ -693,31 +784,41 @@ impl Secp256k1 {
 				nonce.as_ptr(),
 				&mut min,
 				&mut max,
-				commit.as_ptr(),
+				&commit,
 				proof.proof.as_ptr(),
 				proof.plen as size_t,
 				extra_commit.as_ptr(),
 				0 as size_t,
-				constants::GENERATOR_H.as_ptr(),
+				&ffi::Generator(constants::GENERATOR_H),
 			) == 1
 		};
 
-		ProofInfo {
+		// Note: Failure of secp256k1_rangeproof_rewind it is OK result. secp256k1_rangeproof_rewind
+		//  response defines success flag value
+		Ok(ProofInfo {
 			success: success,
 			value: value,
-			message: ProofMessage::from_bytes(&message),
+			message: ProofMessage::from_bytes(&message)?,
 			blinding: SecretKey([0; constants::SECRET_KEY_SIZE]),
 			mlen: mlen,
 			min: min,
 			max: max,
 			exp: 0,
 			mantissa: 0,
-		}
+		})
 	}
 
 	/// General information extracted from a range proof. Does not provide any
 	/// information about the value or the message (see rewind).
-	pub fn range_proof_info(&self, proof: RangeProof) -> ProofInfo {
+	#[cfg(not(feature = "bullet-proof-sizing"))]
+	pub fn range_proof_info(&self, proof: RangeProof) -> Result<ProofInfo, Error> {
+		if self.caps == ContextFlag::None || self.caps == ContextFlag::SignOnly {
+			return Err(Error::IncapableContext);
+		}
+		if !proof.is_valid() {
+			return Err(Error::InvalidRangeProof)
+		}
+
 		let mut exp: i32 = 0;
 		let mut mantissa: i32 = 0;
 		let mut min: u64 = 0;
@@ -732,18 +833,24 @@ impl Secp256k1 {
 				&mut max,
 				proof.proof.as_ptr(),
 				proof.plen as size_t,
-			) == 1
+			)
 		};
-		ProofInfo {
-			success: success,
-			value: 0,
-			message: ProofMessage::empty(),
-			blinding: SecretKey([0; constants::SECRET_KEY_SIZE]),
-			mlen: 0,
-			min: min,
-			max: max,
-			exp: exp,
-			mantissa: mantissa,
+
+		if success == 1 {
+			Ok(ProofInfo {
+				success: true,
+				value: 0,
+				message: ProofMessage::empty(),
+				blinding: SecretKey([0; constants::SECRET_KEY_SIZE]),
+				mlen: 0,
+				min: min,
+				max: max,
+				exp: exp,
+				mantissa: mantissa,
+			})
+		}
+		else {
+			Err(Error::InvalidRangeProof)
 		}
 	}
 
@@ -751,14 +858,18 @@ impl Secp256k1 {
 	/// bounds, relying on the blinding factor and value. If a message is passed,
 	/// it will be truncated or padded to exactly BULLET_PROOF_MSG_SIZE bytes
 	pub fn bullet_proof(
-		&self,
+		&mut self,
 		value: u64,
 		blind: SecretKey,
 		rewind_nonce: SecretKey,
 		private_nonce: SecretKey,
 		extra_data_in: Option<Vec<u8>>,
 		message: Option<ProofMessage>,
-	) -> RangeProof {
+	) -> Result<RangeProof, Error> {
+		if self.caps == ContextFlag::None || self.caps == ContextFlag::SignOnly || self.caps == ContextFlag::VerifyOnly {
+			return Err(Error::IncapableContext);
+		}
+
 		let mut proof = [0; constants::MAX_PROOF_SIZE];
 		let mut plen = constants::MAX_PROOF_SIZE as size_t;
 
@@ -775,9 +886,9 @@ impl Secp256k1 {
 		let message_ptr = match message.as_mut() {
 			Some(m) => {
 				while m.len() < constants::BULLET_PROOF_MSG_SIZE {
-					m.push(0u8);
+					m.push(0u8)?;
 				}
-				m.truncate(constants::BULLET_PROOF_MSG_SIZE);
+				m.truncate(constants::BULLET_PROOF_MSG_SIZE)?;
 				m.as_ptr()
 			},
 			None => ptr::null(),
@@ -789,12 +900,20 @@ impl Secp256k1 {
 		let t_two = ptr::null_mut();
 		let commits = ptr::null_mut();
 
-		let _success = unsafe {
+		let shared_gen = self.shared_generators()?;
+
+		let success = unsafe {
 			let scratch = ffi::secp256k1_scratch_space_create(self.ctx, SCRATCH_SPACE_SIZE);
+			// Note ffi::secp256k1_scratch_space_create will not return the NULL, it will crash instead.
+			//  Checking for null for extra layer
+			if scratch.is_null() {
+				return Err(Error::AllocationError);
+			}
+
 			let result = ffi::secp256k1_bulletproof_rangeproof_prove(
 				self.ctx,
 				scratch,
-				shared_generators(self.ctx),
+				shared_gen.as_ptr(),
 				proof.as_mut_ptr(),
 				&mut plen,
 				tau_x,
@@ -805,7 +924,7 @@ impl Secp256k1 {
 				blind_vec.as_ptr(),
 				commits,
 				1,
-				constants::GENERATOR_H.as_ptr(),
+				&ffi::Generator(constants::GENERATOR_H),
 				n_bits as size_t,
 				rewind_nonce.as_ptr(),
 				private_nonce.as_ptr(),
@@ -820,15 +939,21 @@ impl Secp256k1 {
 			result == 1
 		};
 
-		RangeProof {
-			proof: proof,
-			plen: plen as usize,
+		if success && plen <= constants::MAX_PROOF_SIZE {
+			Ok(RangeProof {
+				proof: proof,
+				plen: plen as usize,
+			})
+		}
+		else {
+			Err(Error::RangeProofGeneration)
 		}
 	}
 
 	/// Produces a bullet proof for multi-party commitment
+	/// Note, 
 	pub fn bullet_proof_multisig(
-		&self,
+		&mut self,
 		value: u64,
 		blind: SecretKey,
 		nonce: SecretKey,
@@ -840,7 +965,34 @@ impl Secp256k1 {
 		commits: Vec<Commitment>,
 		private_nonce: Option<&SecretKey>,
 		step: u8, // 0 for last step. 1 for first step.
-	) -> Option<RangeProof> {
+	) -> Result<Option<RangeProof>, Error> {
+		if self.caps == ContextFlag::None || self.caps == ContextFlag::SignOnly || self.caps == ContextFlag::VerifyOnly {
+			return Err(Error::IncapableContext);
+		}
+
+		if commits.len() != 1 {
+			return Err(Error::InvalidParameters);
+		}
+
+		// Match the exact pointer/nullability contract enforced by the C API.
+		let has_tau_x = tau_x.is_some();
+		let has_t_one = t_one.is_some();
+		let has_t_two = t_two.is_some();
+		let has_private_nonce = private_nonce.is_some();
+		match step {
+			1 => {
+				if has_tau_x || !has_t_one || !has_t_two || !has_private_nonce {
+					return Err(Error::InvalidParameters);
+				}
+			},
+			2 | 0 => {
+				if !has_tau_x || !has_t_one || !has_t_two || !has_private_nonce {
+					return Err(Error::InvalidParameters);
+				}
+			},
+			_ => return Err(Error::InvalidParameters),
+		}
+
 		let last_step = if 0 == step { true } else { false };
 		let first_step = if 1 == step { true } else { false };
 
@@ -861,9 +1013,9 @@ impl Secp256k1 {
 		let message_ptr = match message.as_mut() {
 			Some(m) => {
 				while m.len() < constants::BULLET_PROOF_MSG_SIZE {
-					m.push(0u8);
+					m.push(0u8)?;
 				}
-				m.truncate(constants::BULLET_PROOF_MSG_SIZE);
+				m.truncate(constants::BULLET_PROOF_MSG_SIZE)?;
 				m.as_ptr()
 			},
 			None => ptr::null(),
@@ -877,24 +1029,20 @@ impl Secp256k1 {
 		let t_one_ptr;
 		let t_two_ptr;
 		if first_step {
-			t_one_ptr = is_zero_pubkey!(ignore  => t_one);
-			t_two_ptr = is_zero_pubkey!(ignore  => t_two);
+			t_one_ptr = is_valid_pubkey!(ignore  => t_one);
+			t_two_ptr = is_valid_pubkey!(ignore  => t_two);
 		} else {
-			t_one_ptr = is_zero_pubkey!(retnone => t_one);
-			t_two_ptr = is_zero_pubkey!(retnone => t_two);
+			t_one_ptr = is_valid_pubkey!(retnone => &self, t_one);
+			t_two_ptr = is_valid_pubkey!(retnone => &self, t_two);
 		};
 
 		let commit_vec;
 		let commit_ptr_vec;
 		let commit_ptr_vec_ptr = if commits.len() > 0 {
-			commit_vec = match map_vec!(commits, |c| self.commit_parse(c.0))
+			commit_vec = map_vec!(commits, |c| self.commit_parse(c.0))
 				.into_iter()
-				.collect::<Result<Vec<_>, _>>()
-			{
-				Ok(v) => v,
-				Err(_) => return None,
-			};
-			commit_ptr_vec = map_vec!(commit_vec, |c| c.as_ptr());
+				.collect::<Result<Vec<_>, _>>()?;
+			commit_ptr_vec = map_vec!(commit_vec, |c| c as *const _);
 			commit_ptr_vec.as_ptr()
 		} else {
 			ptr::null()
@@ -905,12 +1053,20 @@ impl Secp256k1 {
 			None => ptr::null(),
 		};
 
-		let _success = unsafe {
+		let shared_gen = self.shared_generators()?;
+
+		let success = unsafe {
 			let scratch = ffi::secp256k1_scratch_space_create(self.ctx, SCRATCH_SPACE_SIZE);
+			// Note ffi::secp256k1_scratch_space_create will not return the NULL, it will crash instead.
+			//  Checking for null for extra layer
+			if scratch.is_null() {
+				return Err(Error::AllocationError);
+			}
+
 			let result = ffi::secp256k1_bulletproof_rangeproof_prove(
 				self.ctx,
 				scratch,
-				shared_generators(self.ctx),
+				shared_gen.as_ptr(),
 				if last_step {
 					proof.as_mut_ptr()
 				} else {
@@ -929,7 +1085,7 @@ impl Secp256k1 {
 				blind_vec.as_ptr(),
 				commit_ptr_vec_ptr,
 				1,
-				constants::GENERATOR_H.as_ptr(),
+				&ffi::Generator(constants::GENERATOR_H),
 				n_bits as size_t,
 				nonce.as_ptr(),
 				private_nonce,
@@ -943,23 +1099,41 @@ impl Secp256k1 {
 			result == 1
 		};
 
+		if !success {
+			return Err( Error::RangeProofGeneration );
+		}
+
 		if last_step {
-			Some(RangeProof {
+			if plen > constants::MAX_PROOF_SIZE {
+				return Err(Error::RangeProofGeneration);
+			}
+
+			Ok(Some(RangeProof {
 				proof: proof,
 				plen: plen as usize,
-			})
+			}))
 		} else {
-			None
+			Ok(None)
 		}
 	}
 
 	/// Verify with bullet proof that a committed value is positive
+	/// Note: resulting Error::InvalidRangeProof can be generated in case of internal error.
+	///    The false negative is accepted
 	pub fn verify_bullet_proof(
-		&self,
+		&mut self,
 		commit: Commitment,
 		proof: RangeProof,
 		extra_data_in: Option<Vec<u8>>,
 	) -> Result<ProofRange, Error> {
+		if self.caps == ContextFlag::None || self.caps == ContextFlag::SignOnly {
+			return Err(Error::IncapableContext);
+		}
+
+		if !proof.is_valid() {
+			return Err(Error::InvalidRangeProof);
+		}
+
 		let n_bits = 64;
 
 		let extra_data;
@@ -973,24 +1147,33 @@ impl Secp256k1 {
 
 		let commit = self.commit_parse(commit.0)?;
 
+		let shared_gen = self.shared_generators()?;
+
 		let success = unsafe {
 			let scratch = ffi::secp256k1_scratch_space_create(self.ctx, SCRATCH_SPACE_SIZE);
+			// Note ffi::secp256k1_scratch_space_create will not return the NULL, it will crash instead.
+			//  Checking for null for extra layer
+			if scratch.is_null() {
+				return Err(Error::AllocationError);
+			}
+
 			let result = ffi::secp256k1_bulletproof_rangeproof_verify(
 				self.ctx,
 				scratch,
-				shared_generators(self.ctx),
+				shared_gen.as_ptr(),
 				proof.proof.as_ptr(),
 				proof.plen as size_t,
 				ptr::null(), // min_values: NULL for all-zeroes minimum values to prove ranges above
-				commit.0.as_ptr(),
+				&commit,
 				1,
 				n_bits as size_t,
-				constants::GENERATOR_H.as_ptr(),
+				&ffi::Generator(constants::GENERATOR_H),
 				extra_data,
 				extra_data_len as size_t,
 			);
-			//			ffi::secp256k1_bulletproof_generators_destroy(self.ctx, gens);
+
 			ffi::secp256k1_scratch_space_destroy(scratch);
+
 			result == 1
 		};
 
@@ -1005,46 +1188,58 @@ impl Secp256k1 {
 	}
 
 	/// Verify with bullet proof that a committed value is positive
+	/// Note: InvalidRangeProof error can be returned because of internal errors.
+	///     false negative is accepted.
 	pub fn verify_bullet_proof_multi(
-		&self,
+		&mut self,
 		commits: Vec<Commitment>,
 		proofs: Vec<RangeProof>,
 		extra_data_in: Option<Vec<Vec<u8>>>,
 	) -> Result<ProofRange, Error> {
+		if self.caps == ContextFlag::None || self.caps == ContextFlag::SignOnly {
+			return Err(Error::IncapableContext);
+		}
+
+		if commits.len() == 0 || commits.len() != proofs.len() {
+			return Err(Error::InvalidParameters);
+		}
+
 		let n_bits = 64;
 
-		let proof_size = if proofs.len() > 0 {
-			proofs[0].plen
-		} else {
-			constants::SINGLE_BULLET_PROOF_SIZE
-		};
+		let proof_size = proofs[0].plen;
+		if proof_size > constants::MAX_PROOF_SIZE {
+			return Err(Error::InvalidParameters);
+		}
+
+		for pr in &proofs {
+			if !pr.is_valid() || pr.plen != proof_size {
+				return Err(Error::InvalidParameters);
+			}
+		}
 
 		let commit_vec = map_vec!(commits, |c| self.commit_parse(c.0))
 			.into_iter()
 			.collect::<Result<Vec<_>, _>>()?;
-		let commit_vec = map_vec!(commit_vec, |c| c.as_ptr());
+		let commit_vec = map_vec!(commit_vec, |c| c as *const _);
 		let proof_vec = map_vec!(proofs, |p| p.proof.as_ptr());
 		//		let min_values = vec![0; proofs.len()];
 
 		// array of generator multiplied by value in pedersen commitments (cannot be NULL)
-		let value_gen_vec = {
+		let mut value_gen_vec = {
 			let min_len = if proof_vec.len() > 0 {
 				proof_vec.len()
 			} else {
 				1
 			};
-			let gen_size = constants::GENERATOR_SIZE;
-			let mut value_gen_vec = vec![0; min_len * gen_size];
-			for i in 0..min_len {
-				value_gen_vec[i * gen_size..(i + 1) * gen_size]
-					.clone_from_slice(&constants::GENERATOR_H[..]);
-			}
-			value_gen_vec
+			vec![ffi::Generator(constants::GENERATOR_H); min_len]
 		};
 
 		// converting vec of vecs to expected pointer
-		let (extra_data_vec, extra_data_lengths) = match extra_data_in.as_ref() {
+		let (extra_data_vec, mut extra_data_lengths) = match extra_data_in.as_ref() {
 			Some(ed) => {
+				if ed.len() != proof_vec.len() {
+					return Err(Error::InvalidParameters);
+				}
 				let extra_data_vec = map_vec!(ed, |d| d.as_ptr());
 				let extra_data_lengths = map_vec![ed, |d| d.len()];
 				(extra_data_vec, extra_data_lengths)
@@ -1056,12 +1251,20 @@ impl Secp256k1 {
 			}
 		};
 
+		let shared_gen = self.shared_generators()?;
+
 		let success = unsafe {
 			let scratch = ffi::secp256k1_scratch_space_create(self.ctx, SCRATCH_SPACE_SIZE);
+			// Note ffi::secp256k1_scratch_space_create will not return the NULL, it will crash instead.
+			//  Checking for null for extra layer
+			if scratch.is_null() {
+				return Err(Error::AllocationError);
+			}
+
 			let result = ffi::secp256k1_bulletproof_rangeproof_verify_multi(
 				self.ctx,
 				scratch,
-				shared_generators(self.ctx),
+				shared_gen.as_ptr(),
 				proof_vec.as_ptr(),
 				proof_vec.len(),
 				proof_size,
@@ -1069,11 +1272,10 @@ impl Secp256k1 {
 				commit_vec.as_ptr(),
 				1,
 				n_bits as size_t,
-				value_gen_vec.as_ptr(),
+				value_gen_vec.as_mut_ptr(),
 				extra_data_vec.as_ptr(),
-				extra_data_lengths.as_ptr(),
+				extra_data_lengths.as_mut_ptr(),
 			);
-			//			ffi::secp256k1_bulletproof_generators_destroy(self.ctx, gens);
 			ffi::secp256k1_scratch_space_destroy(scratch);
 			result == 1
 		};
@@ -1088,18 +1290,32 @@ impl Secp256k1 {
 		}
 	}
 
-	/// Rewind a bullet proof to get the value and Blinding factor back out
+	/// Rewind a bullet proof to get the value and blinding factor back out.
+	/// A distinct `private_nonce` must be provided here if we want to validate that proof's taux and mu.
+	/// Note: Rewind doesn't validate the proof! It is expected that caller already validated proof
 	pub fn rewind_bullet_proof(
 		&self,
 		commit: Commitment,
 		nonce: SecretKey,
+		private_nonce: Option<SecretKey>,
 		extra_data_in: Option<Vec<u8>>,
 		proof: RangeProof,
 	) -> Result<ProofInfo, Error> {
-		let (extra_data_len, extra_data) = match extra_data_in.as_ref() {
-			Some(d) => (d.len(), d.as_ptr()),
-			None => (0, ptr::null()),
-		};
+		if self.caps == ContextFlag::None || self.caps == ContextFlag::SignOnly || self.caps == ContextFlag::VerifyOnly {
+			return Err(Error::IncapableContext);
+		}
+		if !proof.is_valid() {
+			return Err(Error::InvalidRangeProof);
+		}
+
+			let (extra_data_len, extra_data) = match extra_data_in.as_ref() {
+				Some(d) => (d.len(), d.as_ptr()),
+				None => (0, ptr::null()),
+			};
+			let private_nonce = match private_nonce.as_ref() {
+				Some(n) => n.as_ptr(),
+				None => ptr::null(),
+			};
 
 		let mut blind_out = [0u8; constants::SECRET_KEY_SIZE];
 		let mut value_out = 0;
@@ -1108,21 +1324,29 @@ impl Secp256k1 {
 
 		let success = unsafe {
 			let scratch = ffi::secp256k1_scratch_space_create(self.ctx, SCRATCH_SPACE_SIZE);
+			// Note ffi::secp256k1_scratch_space_create will not return the NULL, it will crash instead.
+			//  Checking for null for extra layer
+			if scratch.is_null() {
+				return Err(Error::AllocationError);
+			}
+
 			let result = ffi::secp256k1_bulletproof_rangeproof_rewind(
 				self.ctx,
 				&mut value_out,
 				blind_out.as_mut_ptr(),
 				proof.proof.as_ptr(),
 				proof.plen as size_t,
-				0,
-				commit.as_ptr(),
-				constants::GENERATOR_H.as_ptr(),
+				ptr::null(), // Null is matching 0 now.
+				&commit,
+				&ffi::Generator(constants::GENERATOR_H),
+				&ffi::Generator(constants::GENERATOR_G),
 				nonce.as_ptr(),
+				private_nonce,
 				extra_data,
 				extra_data_len as size_t,
 				message_out.as_mut_ptr(),
 			);
-			//			ffi::secp256k1_bulletproof_generators_destroy(self.ctx, gens);
+
 			ffi::secp256k1_scratch_space_destroy(scratch);
 			result == 1
 		};
@@ -1132,7 +1356,7 @@ impl Secp256k1 {
 				success: true,
 				value: value_out,
 				blinding: SecretKey(blind_out),
-				message: ProofMessage::from_bytes(&message_out),
+				message: ProofMessage::from_bytes(&message_out)?,
 				mlen: 0,
 				min: 0,
 				max: u64::MAX,
@@ -1143,6 +1367,25 @@ impl Secp256k1 {
 			Err(Error::InvalidRangeProof)
 		}
 	}
+
+	fn shared_generators(&mut self) -> Result<NonNull<ffi::BulletproofGenerators>, Error> {
+		match self.bulletproof_gen {
+			Some(bulletproof_gen) => Ok(bulletproof_gen),
+			None => {
+				let gen = unsafe {
+					ffi::secp256k1_bulletproof_generators_create(
+						self.ctx,
+						&ffi::Generator(constants::GENERATOR_G),
+						crate::pedersen::MAX_GENERATORS,
+					)
+				};
+				let gen = NonNull::new(gen).ok_or(Error::GenericError)?;
+				self.bulletproof_gen = Some(gen);
+				Ok(gen)
+			}
+		}
+	}
+
 }
 
 #[cfg(test)]
@@ -1152,15 +1395,15 @@ mod tests {
 	use crate::key::{PublicKey, SecretKey, ONE_KEY, ZERO_KEY};
 	use crate::ContextFlag;
 	use crate::constants;
-
-	use rand::{thread_rng, Rng};
+	use rand::TryRng;
+	use rand::rngs::SysRng;
 
 	use crate::pedersen::tests::chrono::prelude::*;
 
 	#[test]
 	fn commit_parse_ser() {
 		fn commit(value: u64) -> Commitment {
-			let secp = Secp256k1::with_caps(ContextFlag::Commit);
+			let secp = Secp256k1::with_caps(ContextFlag::Commit).unwrap();
 			let blinding = ZERO_KEY;
 			secp.commit(value, blinding).unwrap()
 		}
@@ -1168,47 +1411,52 @@ mod tests {
 			0xc6, 0x04, 0x7f, 0x94, 0x41, 0xed, 0x7d, 0x6d, 0x30, 0x45, 0x40, 0x6e, 0x95, 0xc0, 0x7c, 0xd8,
 			0x5c, 0x77, 0x8e, 0x4b, 0x8c, 0xef, 0x3c, 0xa7, 0xab, 0xac, 0x09, 0xb9, 0x5c, 0x70, 0x9e, 0xe5
 		];
-		let secp = Secp256k1::with_caps(ContextFlag::Commit);
+		let secp = Secp256k1::with_caps(ContextFlag::Commit).unwrap();
 		let commit_i = secp.commit_parse(two_g).unwrap();
-		let comm = secp.commit_ser(commit_i.0).unwrap();
+		let comm = secp.commit_ser(commit_i).unwrap();
 		assert_eq!(comm, Commitment(two_g));
 
 		let c5 = commit(5);
 		let commit_i = secp.commit_parse(c5.0).unwrap();
-		let comm = secp.commit_ser(commit_i.0).unwrap();
+		let comm = secp.commit_ser(commit_i).unwrap();
 		assert_eq!(comm, c5);
+		secp.validate_commitment(&c5).unwrap();
+		assert_eq!(
+			secp.validate_commitment(&Commitment([1u8; constants::PEDERSEN_COMMITMENT_SIZE])),
+			Err(Error::InvalidCommit)
+		);
 
 	}
 
 	#[test]
 	fn test_verify_commit_sum_zero_keys() {
 		fn commit(value: u64) -> Commitment {
-			let secp = Secp256k1::with_caps(ContextFlag::Commit);
+			let secp = Secp256k1::with_caps(ContextFlag::Commit).unwrap();
 			let blinding = ZERO_KEY;
 			secp.commit(value, blinding).unwrap()
 		}
 
-		let secp = Secp256k1::with_caps(ContextFlag::Commit);
+		let secp = Secp256k1::with_caps(ContextFlag::Commit).unwrap();
 
-		assert!(secp.verify_commit_sum(vec![], vec![],));
+		assert!(secp.verify_commit_sum(vec![], vec![],).unwrap());
 
-		assert!(secp.verify_commit_sum(vec![commit(5)], vec![commit(5)],));
+		assert!(secp.verify_commit_sum(vec![commit(5)], vec![commit(5)],).unwrap());
 
-		assert!(secp.verify_commit_sum(vec![commit(3), commit(2)], vec![commit(5)]));
+		assert!(secp.verify_commit_sum(vec![commit(3), commit(2)], vec![commit(5)]).unwrap());
 
-		assert!(secp.verify_commit_sum(vec![commit(2), commit(4)], vec![commit(1), commit(5)]));
+		assert!(secp.verify_commit_sum(vec![commit(2), commit(4)], vec![commit(1), commit(5)]).unwrap());
 	}
 
 	#[test]
 	fn test_verify_commit_sum_one_keys() {
-		let secp = Secp256k1::with_caps(ContextFlag::Commit);
+		let secp = Secp256k1::with_caps(ContextFlag::Commit).unwrap();
 
 		fn commit(value: u64, blinding: SecretKey) -> Commitment {
-			let secp = Secp256k1::with_caps(ContextFlag::Commit);
+			let secp = Secp256k1::with_caps(ContextFlag::Commit).unwrap();
 			secp.commit(value, blinding).unwrap()
 		}
 
-		assert!(secp.verify_commit_sum(vec![commit(5, ONE_KEY)], vec![commit(5, ONE_KEY)]));
+		assert!(secp.verify_commit_sum(vec![commit(5, ONE_KEY)], vec![commit(5, ONE_KEY)]).unwrap());
 
 		// we expect this not to verify
 		// even though the values add up to 0
@@ -1217,7 +1465,7 @@ mod tests {
 			secp.verify_commit_sum(
 				vec![commit(3, ONE_KEY), commit(2, ONE_KEY)],
 				vec![commit(5, ONE_KEY)],
-			),
+			).unwrap(),
 			false
 		);
 
@@ -1227,20 +1475,31 @@ mod tests {
 		assert!(secp.verify_commit_sum(
 			vec![commit(3, ONE_KEY), commit(2, ONE_KEY)],
 			vec![commit(5, two_key)],
-		));
+		).unwrap());
+	}
+
+	#[test]
+	fn test_blind_sum_returns_zero_secret_key_for_zero_result() {
+		let secp = Secp256k1::with_caps(ContextFlag::Commit).unwrap();
+		let blind = SecretKey::new(&secp, &mut SysRng).unwrap();
+
+		assert_eq!(
+			secp.blind_sum(vec![blind.clone()], vec![blind]),
+			Err(Error::ZeroSecretKey)
+		);
 	}
 
 	#[test]
 	fn test_verify_commit_sum_random_keys() {
-		let secp = Secp256k1::with_caps(ContextFlag::Commit);
+		let secp = Secp256k1::with_caps(ContextFlag::Commit).unwrap();
 
 		fn commit(value: u64, blinding: SecretKey) -> Commitment {
-			let secp = Secp256k1::with_caps(ContextFlag::Commit);
+			let secp = Secp256k1::with_caps(ContextFlag::Commit).unwrap();
 			secp.commit(value, blinding).unwrap()
 		}
 
-		let blind_pos = SecretKey::new(&secp, &mut thread_rng());
-		let blind_neg = SecretKey::new(&secp, &mut thread_rng());
+		let blind_pos = SecretKey::new(&secp, &mut SysRng).unwrap();
+		let blind_neg = SecretKey::new(&secp, &mut SysRng).unwrap();
 
 		// now construct blinding factor to net out appropriately
 		let blind_sum = secp.blind_sum(vec![blind_pos.clone()], vec![blind_neg.clone()]).unwrap();
@@ -1248,23 +1507,23 @@ mod tests {
 		assert!(secp.verify_commit_sum(
 			vec![commit(101, blind_pos)],
 			vec![commit(75, blind_neg), commit(26, blind_sum)],
-		));
+		).unwrap());
 	}
 
 	#[test]
 	fn test_verify_commit_sum_random_keys_switch() {
-		let secp = Secp256k1::with_caps(ContextFlag::Commit);
+		let secp = Secp256k1::with_caps(ContextFlag::Commit).unwrap();
 
 		fn commit(value: u64, blinding: SecretKey) -> Commitment {
-			let secp = Secp256k1::with_caps(ContextFlag::Commit);
+			let secp = Secp256k1::with_caps(ContextFlag::Commit).unwrap();
 			secp.commit(value, blinding).unwrap()
 		}
 
 		let pos_value = 101;
 		let neg_value = 75;
 
-		let blind_pos = secp.blind_switch(pos_value, SecretKey::new(&secp, &mut thread_rng())).unwrap();
-		let blind_neg = secp.blind_switch(neg_value, SecretKey::new(&secp, &mut thread_rng())).unwrap();
+		let blind_pos = secp.blind_switch(pos_value, SecretKey::new(&secp, &mut SysRng).unwrap()).unwrap();
+		let blind_neg = secp.blind_switch(neg_value, SecretKey::new(&secp, &mut SysRng).unwrap()).unwrap();
 
 		// now construct blinding factor to net out appropriately
 		let blind_sum = secp.blind_sum(vec![blind_pos.clone()], vec![blind_neg.clone()]).unwrap();
@@ -1273,15 +1532,15 @@ mod tests {
 		assert!(secp.verify_commit_sum(
 			vec![commit(pos_value, blind_pos)],
 			vec![commit(neg_value, blind_neg), commit(diff, blind_sum)],
-		));
+		).unwrap());
 	}
 
 	#[test]
 	// to_pubkey() is not currently working as secp does currently
 	// provide an api to extract a public key from a commitment
 	fn test_to_pubkey() {
-		let secp = Secp256k1::with_caps(ContextFlag::Commit);
-		let blinding = SecretKey::new(&secp, &mut thread_rng());
+		let secp = Secp256k1::with_caps(ContextFlag::Commit).unwrap();
+		let blinding = SecretKey::new(&secp, &mut SysRng).unwrap();
 		let commit = secp.commit(5, blinding).unwrap();
 		let pubkey = commit.to_pubkey(&secp);
 		match pubkey {
@@ -1297,8 +1556,8 @@ mod tests {
 	#[test]
 	fn test_from_pubkey() {
 		for _ in 0..100 {
-			let secp = Secp256k1::with_caps(ContextFlag::Commit);
-			let blinding = SecretKey::new(&secp, &mut thread_rng());
+			let secp = Secp256k1::with_caps(ContextFlag::Commit).unwrap();
+			let blinding = SecretKey::new(&secp, &mut SysRng).unwrap();
 			let commit = secp.commit(1, blinding).unwrap();
 			let pubkey = commit.to_pubkey(&secp);
 			let p = match pubkey {
@@ -1330,12 +1589,12 @@ mod tests {
 
 	#[test]
 	fn test_sign_with_pubkey_from_commitment() {
-		let secp = Secp256k1::with_caps(ContextFlag::Commit);
-		let blinding = SecretKey::new(&secp, &mut thread_rng());
+		let secp = Secp256k1::with_caps(ContextFlag::Commit).unwrap();
+		let blinding = SecretKey::new(&secp, &mut SysRng).unwrap();
 		let commit = secp.commit(0u64, blinding.clone()).unwrap();
 
 		let mut msg = [0u8; 32];
-		thread_rng().fill(&mut msg);
+		SysRng.try_fill_bytes(&mut msg).unwrap();
 		let msg = Message::from_slice(&msg).unwrap();
 
 		let sig = secp.sign(&msg, &blinding).unwrap();
@@ -1352,15 +1611,15 @@ mod tests {
 
 	#[test]
 	fn test_commit_sum() {
-		let secp = Secp256k1::with_caps(ContextFlag::Commit);
+		let secp = Secp256k1::with_caps(ContextFlag::Commit).unwrap();
 
 		fn commit(value: u64, blinding: SecretKey) -> Commitment {
-			let secp = Secp256k1::with_caps(ContextFlag::Commit);
+			let secp = Secp256k1::with_caps(ContextFlag::Commit).unwrap();
 			secp.commit(value, blinding).unwrap()
 		}
 
-		let blind_a = SecretKey::new(&secp, &mut thread_rng());
-		let blind_b = SecretKey::new(&secp, &mut thread_rng());
+		let blind_a = SecretKey::new(&secp, &mut SysRng).unwrap();
+		let blind_b = SecretKey::new(&secp, &mut SysRng).unwrap();
 
 		let commit_a = commit(3, blind_a.clone());
 		let commit_b = commit(2, blind_b.clone());
@@ -1382,56 +1641,57 @@ mod tests {
 
 	#[test]
 	fn test_blind_commit() {
-		let secp = Secp256k1::with_caps(ContextFlag::Commit);
-		let rng = &mut thread_rng();
+		let secp = Secp256k1::with_caps(ContextFlag::Commit).unwrap();
+		let rng = &mut SysRng;
 		let value: u64 = 1;
-		let blind = SecretKey::new(&secp, rng);
+		let blind = SecretKey::new(&secp, rng).unwrap();
 		let blind2 = ONE_KEY;
 		assert_eq!(secp.commit(value, blind.clone()).unwrap(), secp.commit_blind(blind2.clone(), blind.clone()).unwrap());
 		let value: u64 = 2;
-		let blind = SecretKey::new(&secp, rng);
+		let blind = SecretKey::new(&secp, rng).unwrap();
 		assert_ne!(secp.commit(value, blind.clone()).unwrap(), secp.commit_blind(blind2, blind.clone()).unwrap());
-		let blind = SecretKey::new(&secp, rng);
+		let blind = SecretKey::new(&secp, rng).unwrap();
 		let mut blind2 = ZERO_KEY;
-		blind2.0[30] = rng.gen::<u8>();
-		blind2.0[31] = rng.gen::<u8>();
+		blind2.0[30] = SysRng.try_next_u32().unwrap() as u8;
+		blind2.0[31] = SysRng.try_next_u32().unwrap() as u8;
 		let value: u64 = blind2[30] as u64*256 + blind2[31] as u64;
 		assert_eq!(secp.commit(value, blind.clone()).unwrap(), secp.commit_blind(blind2, blind.clone()).unwrap());
 	}
 
+	#[cfg(not(feature = "bullet-proof-sizing"))]
 	#[test]
 	fn test_range_proof() {
-		let secp = Secp256k1::with_caps(ContextFlag::Commit);
-		let blinding = SecretKey::new(&secp, &mut thread_rng());
+		let secp = Secp256k1::with_caps(ContextFlag::Commit).unwrap();
+		let blinding = SecretKey::new(&secp, &mut SysRng).unwrap();
 		let commit = secp.commit(7, blinding.clone()).unwrap();
 		let msg = ProofMessage::empty();
-		let range_proof = secp.range_proof(0, 7, blinding.clone(), commit, msg.clone());
+		let range_proof = secp.range_proof(0, 7, blinding.clone(), commit, msg.clone()).unwrap();
 		let proof_range = secp.verify_range_proof(commit, range_proof).unwrap();
 
 		assert_eq!(proof_range.min, 0);
 
-		let proof_info = secp.range_proof_info(range_proof);
+		let proof_info = secp.range_proof_info(range_proof).unwrap();
 		assert!(proof_info.success);
 		assert_eq!(proof_info.min, 0);
 		// check we get no information back for the value here
 		assert_eq!(proof_info.value, 0);
 
-		let proof_info = secp.rewind_range_proof(commit, range_proof, blinding.clone());
+		let proof_info = secp.rewind_range_proof(commit, range_proof, blinding.clone()).unwrap();
 		assert!(proof_info.success);
 		assert_eq!(proof_info.min, 0);
 		assert_eq!(proof_info.value, 7);
 
 		// check we cannot rewind a range proof without the original nonce
-		let bad_nonce = SecretKey::new(&secp, &mut thread_rng());
-		let bad_info = secp.rewind_range_proof(commit, range_proof, bad_nonce);
+		let bad_nonce = SecretKey::new(&secp, &mut SysRng).unwrap();
+		let bad_info = secp.rewind_range_proof(commit, range_proof, bad_nonce).unwrap();
 		assert_eq!(bad_info.success, false);
 		assert_eq!(bad_info.value, 0);
 
 		// check we can construct and verify a range proof on value 0
 		let commit = secp.commit(0, blinding.clone()).unwrap();
-		let range_proof = secp.range_proof(0, 0, blinding.clone(), commit, msg);
+		let range_proof = secp.range_proof(0, 0, blinding.clone(), commit, msg).unwrap();
 		secp.verify_range_proof(commit, range_proof).unwrap();
-		let proof_info = secp.rewind_range_proof(commit, range_proof, blinding);
+		let proof_info = secp.rewind_range_proof(commit, range_proof, blinding).unwrap();
 		assert!(proof_info.success);
 		assert_eq!(proof_info.min, 0);
 		assert_eq!(proof_info.value, 0);
@@ -1440,11 +1700,11 @@ mod tests {
 	#[test]
 	fn test_bullet_proof_single() {
 		// Test Bulletproofs without message
-		let secp = Secp256k1::with_caps(ContextFlag::Commit);
-		let blinding = SecretKey::new(&secp, &mut thread_rng());
+		let mut secp = Secp256k1::with_caps(ContextFlag::Commit).unwrap();
+		let blinding = SecretKey::new(&secp, &mut SysRng).unwrap();
 		let value = 12345678;
 		let commit = secp.commit(value, blinding.clone()).unwrap();
-		let bullet_proof = secp.bullet_proof(value, blinding.clone(), blinding.clone(), blinding.clone(), None, None);
+		let bullet_proof = secp.bullet_proof(value, blinding.clone(), blinding.clone(), blinding.clone(), None, None).unwrap();
 
 		// correct verification
 		println!("Bullet proof len: {}", bullet_proof.plen);
@@ -1456,7 +1716,7 @@ mod tests {
 		// wrong value committed to
 		let value = 12345678;
 		let wrong_commit = secp.commit(87654321, blinding.clone()).unwrap();
-		let bullet_proof = secp.bullet_proof(value, blinding.clone(), blinding.clone(), blinding.clone(), None, None);
+		let bullet_proof = secp.bullet_proof(value, blinding.clone(), blinding.clone(), blinding.clone(), None, None).unwrap();
 		if !secp
 			.verify_bullet_proof(wrong_commit, bullet_proof, None)
 			.is_err()
@@ -1467,8 +1727,8 @@ mod tests {
 		// wrong blinding
 		let value = 12345678;
 		let commit = secp.commit(value, blinding).unwrap();
-		let blinding = SecretKey::new(&secp, &mut thread_rng());
-		let bullet_proof = secp.bullet_proof(value, blinding.clone(), blinding.clone(), blinding.clone(), None, None);
+		let blinding = SecretKey::new(&secp, &mut SysRng).unwrap();
+		let bullet_proof = secp.bullet_proof(value, blinding.clone(), blinding.clone(), blinding.clone(), None, None).unwrap();
 		if !secp
 			.verify_bullet_proof(commit, bullet_proof, None)
 			.is_err()
@@ -1478,11 +1738,11 @@ mod tests {
 
 		// Commit to some extra data in the bulletproof
 		let extra_data = [0u8; 32].to_vec();
-		let blinding = SecretKey::new(&secp, &mut thread_rng());
+		let blinding = SecretKey::new(&secp, &mut SysRng).unwrap();
 		let value = 12345678;
 		let commit = secp.commit(value, blinding.clone()).unwrap();
 		let bullet_proof =
-			secp.bullet_proof(value, blinding.clone(), blinding.clone(), blinding.clone(), Some(extra_data.clone()), None);
+			secp.bullet_proof(value, blinding.clone(), blinding.clone(), blinding.clone(), Some(extra_data.clone()), None).unwrap();
 		if secp
 			.verify_bullet_proof(commit, bullet_proof, Some(extra_data.clone()))
 			.is_err()
@@ -1503,41 +1763,42 @@ mod tests {
 
 		// Ensure rewinding works
 
-		let blinding = SecretKey::new(&secp, &mut thread_rng());
-		let rewind_nonce = SecretKey::new(&secp, &mut thread_rng());
-		let private_nonce = SecretKey::new(&secp, &mut thread_rng());
+		let blinding = SecretKey::new(&secp, &mut SysRng).unwrap();
+		let rewind_nonce = SecretKey::new(&secp, &mut SysRng).unwrap();
+		let private_nonce = SecretKey::new(&secp, &mut SysRng).unwrap();
 		let value = 12345678;
 		let commit = secp.commit(value, blinding.clone()).unwrap();
 
 		let bullet_proof =
-			secp.bullet_proof(value, blinding.clone(), private_nonce.clone(), private_nonce.clone(), Some(extra_data.clone()), None);
-		// Unwind message with same blinding factor
-		let proof_info = secp
-			.rewind_bullet_proof(commit, private_nonce.clone(), Some(extra_data.clone()), bullet_proof)
-			.unwrap();
+			secp.bullet_proof(value, blinding.clone(), private_nonce.clone(), private_nonce.clone(), Some(extra_data.clone()), None).unwrap();
+			// Unwind message with same blinding factor
+			let proof_info = secp
+				.rewind_bullet_proof(commit, private_nonce.clone(), None, Some(extra_data.clone()), bullet_proof)
+				.unwrap();
 		assert_eq!(proof_info.value, value);
-		assert_eq!(blinding, proof_info.blinding);
+		assert!(blinding == proof_info.blinding);
 
 		// unwinding with wrong nonce data should puke
-		let proof_info = secp.rewind_bullet_proof(
-			commit,
-			blinding.clone(),
-			Some(extra_data.clone().to_vec()),
-			bullet_proof,
-		);
+			let proof_info = secp.rewind_bullet_proof(
+				commit,
+				blinding.clone(),
+				None,
+				Some(extra_data.clone().to_vec()),
+				bullet_proof,
+			);
 		if !proof_info.is_err() {
 			panic!("Bullet proof verify with message should have errored.");
 		}
 
-		// unwinding with wrong extra data should puke
-		let proof_info = secp.rewind_bullet_proof(commit, private_nonce.clone(), None, bullet_proof);
-		if !proof_info.is_err() {
-			panic!("Bullet proof verify with message should have errored.");
-		}
+			// unwinding with wrong extra data should puke
+			let proof_info = secp.rewind_bullet_proof(commit, private_nonce.clone(), None, None, bullet_proof);
+			if !proof_info.is_err() {
+				panic!("Bullet proof verify with message should have errored.");
+			}
 
 		// Ensure including a message also works
 		let message_bytes: [u8; 20] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20];
-		let message = ProofMessage::from_bytes(&message_bytes);
+		let message = ProofMessage::from_bytes(&message_bytes).unwrap();
 
 		let bullet_proof = secp.bullet_proof(
 			value,
@@ -1546,11 +1807,11 @@ mod tests {
 			private_nonce.clone(),
 			Some(extra_data.clone()),
 			Some(message.clone()),
-		);
-		// Unwind message with same blinding factor
-		let proof_info = secp
-			.rewind_bullet_proof(commit, rewind_nonce, Some(extra_data.clone()), bullet_proof)
-			.unwrap();
+		).unwrap();
+			// Unwind message with same blinding factor
+			let proof_info = secp
+				.rewind_bullet_proof(commit, rewind_nonce, Some(private_nonce.clone()), Some(extra_data.clone()), bullet_proof)
+				.unwrap();
 		assert_eq!(proof_info.value, value);
 		assert_eq!(proof_info.message, message);
 	}
@@ -1559,7 +1820,7 @@ mod tests {
 	fn test_bullet_proof_multisig() {
 		let multisig_bp =
 			|v, nonce: SecretKey, ca, cb, ba, bb, msg, extra| -> (RangeProof, Result<ProofRange, Error>) {
-				let secp = Secp256k1::with_caps(ContextFlag::Commit);
+				let mut secp = Secp256k1::with_caps(ContextFlag::Commit).unwrap();
 				let blinding_a: SecretKey = ba;
 				let value: u64 = v;
 				let partial_commit_a: Commitment = ca;
@@ -1580,12 +1841,12 @@ mod tests {
 
 				let common_nonce = nonce;
 
-				let private_nonce_a = SecretKey::new(&secp, &mut thread_rng());
-				let private_nonce_b = SecretKey::new(&secp, &mut thread_rng());
+				let private_nonce_a = SecretKey::new(&secp, &mut SysRng).unwrap();
+				let private_nonce_b = SecretKey::new(&secp, &mut SysRng).unwrap();
 
 				// 1st step on party A: generate t_one and t_two, and sends to party B
-				let mut t_one_a = PublicKey::new();
-				let mut t_two_a = PublicKey::new();
+				let mut t_one_a = PublicKey::blank();
+				let mut t_two_a = PublicKey::blank();
 				secp.bullet_proof_multisig(
 					value,
 					blinding_a.clone(),
@@ -1598,11 +1859,11 @@ mod tests {
 					commits.clone(),
 					Some(&private_nonce_a),
 					1,
-				);
+				).unwrap();
 
 				// 1st step on party B: generate t_one and t_two, and sends to party A
-				let mut t_one_b = PublicKey::new();
-				let mut t_two_b = PublicKey::new();
+				let mut t_one_b = PublicKey::blank();
+				let mut t_two_b = PublicKey::blank();
 				secp.bullet_proof_multisig(
 					value,
 					blinding_b.clone(),
@@ -1615,7 +1876,7 @@ mod tests {
 					commits.clone(),
 					Some(&private_nonce_b),
 					1,
-				);
+				).unwrap();
 
 				// 1st step on both party A and party B: sum up both t_one and both t_two.
 				let mut pubkeys = vec![];
@@ -1629,7 +1890,7 @@ mod tests {
 				let mut t_two_sum = PublicKey::from_combination(&secp, pubkeys.clone()).unwrap();
 
 				// 2nd step on party A: use t_one_sum and t_two_sum to generate tau_x, and sent to party B.
-				let mut tau_x_a = SecretKey::new(&secp, &mut thread_rng());
+				let mut tau_x_a = SecretKey::new(&secp, &mut SysRng).unwrap();
 				secp.bullet_proof_multisig(
 					value,
 					blinding_a.clone(),
@@ -1642,10 +1903,10 @@ mod tests {
 					commits.clone(),
 					Some(&private_nonce_a),
 					2,
-				);
+				).unwrap();
 
 				// 2nd step on party B: use t_one_sum and t_two_sum to generate tau_x, and send to party A.
-				let mut tau_x_b = SecretKey::new(&secp, &mut thread_rng());
+				let mut tau_x_b = SecretKey::new(&secp, &mut SysRng).unwrap();
 				secp.bullet_proof_multisig(
 					value,
 					blinding_b.clone(),
@@ -1658,7 +1919,7 @@ mod tests {
 					commits.clone(),
 					Some(&private_nonce_b),
 					2,
-				);
+				).unwrap();
 
 				// 2nd step on both party A and B: sum up both tau_x
 				let mut tau_x_sum = tau_x_a;
@@ -1678,24 +1939,24 @@ mod tests {
 						commits.clone(),
 						Some(&private_nonce_a),
 						0,
-					).unwrap();
+					).unwrap().unwrap();
 
 				// correct verification
-				println!("MultiSig Bullet proof len: {:}", bullet_proof.len());
+				println!("MultiSig Bullet proof len: {:}", bullet_proof.len().unwrap());
 				let proof_range = secp.verify_bullet_proof(commit, bullet_proof, None);
 
 				return (bullet_proof, proof_range);
 			};
 
-		let secp = Secp256k1::with_caps(ContextFlag::Commit);
+		let secp = Secp256k1::with_caps(ContextFlag::Commit).unwrap();
 		let value: u64 = 12345678;
 
-		let common_nonce = SecretKey::new(&secp, &mut thread_rng());
+		let common_nonce = SecretKey::new(&secp, &mut SysRng).unwrap();
 
-		let blinding_a = SecretKey::new(&secp, &mut thread_rng());
+		let blinding_a = SecretKey::new(&secp, &mut SysRng).unwrap();
 		let partial_commit_a = secp.commit(value, blinding_a.clone()).unwrap();
 
-		let blinding_b = SecretKey::new(&secp, &mut thread_rng());
+		let blinding_b = SecretKey::new(&secp, &mut SysRng).unwrap();
 		let partial_commit_b = secp.commit(0, blinding_b.clone()).unwrap();
 
 		// 1. Test Bulletproofs multisig without message
@@ -1728,7 +1989,7 @@ mod tests {
 		}
 
 		// 3. wrong blinding
-		let wrong_blinding = SecretKey::new(&secp, &mut thread_rng());
+		let wrong_blinding = SecretKey::new(&secp, &mut SysRng).unwrap();
 		let (_, proof_range) = multisig_bp(
 			value,
 			common_nonce.clone(),
@@ -1745,7 +2006,7 @@ mod tests {
 
 		// 4. Commit to a message in the bulletproof
 		let message_bytes: [u8; 16] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
-		let message = ProofMessage::from_bytes(&message_bytes);
+		let message = ProofMessage::from_bytes(&message_bytes).unwrap();
 		let (_, proof_range) = multisig_bp(
 			value,
 			common_nonce,
@@ -1763,7 +2024,7 @@ mod tests {
 		// Ensure rewinding works
 		/*
 		let mut extra_data = [0u8; 32];
-		thread_rng().fill(&mut extra_data);
+		rng().fill_bytes(&mut extra_data);
 
 		let (bullet_proof, _) = multisig_bp(
 			value,
@@ -1779,12 +2040,13 @@ mod tests {
 		let commit = secp
 			.commit_sum(vec![partial_commit_a, partial_commit_b], vec![])
 			.unwrap();
-		let proof_info = secp.rewind_bullet_proof(
-			commit,
-			common_nonce.clone(),
-			Some(extra_data.to_vec()),
-			bullet_proof,
-		);
+			let proof_info = secp.rewind_bullet_proof(
+				commit,
+				common_nonce.clone(),
+				None,
+				Some(extra_data.to_vec()),
+				bullet_proof,
+			);
 		println!("proof_info after rewind: {:#?}", proof_info);
 
 		let proof_info = proof_info.unwrap();
@@ -1795,18 +2057,19 @@ mod tests {
 		assert_eq!(blinding, proof_info.blinding);
 
 		// 6. Rewind with wrong nonce data should fail
-		let proof_info = secp.rewind_bullet_proof(
-			commit,
-			blinding.clone(),
-			Some(extra_data.to_vec()),
-			bullet_proof,
-		);
+			let proof_info = secp.rewind_bullet_proof(
+				commit,
+				blinding.clone(),
+				None,
+				Some(extra_data.to_vec()),
+				bullet_proof,
+			);
 		if !proof_info.is_err() {
 			panic!("Bullet proof verify with wrong nonce should have error.");
 		}
 
 		// 7. unwinding with wrong extra data should fail
-		let proof_info = secp.rewind_bullet_proof(commit, common_nonce.clone(), None, bullet_proof);
+			let proof_info = secp.rewind_bullet_proof(commit, common_nonce.clone(), None, None, bullet_proof);
 		if !proof_info.is_err() {
 			panic!("Bullet proof verify with wrong extra data should have error.");
 		}
@@ -1827,59 +2090,162 @@ mod tests {
 		);
 		// 8. Rewind message with same nonce
 		let proof_info = secp
-			.rewind_bullet_proof(
-				commit,
-				common_nonce.clone(),
-				Some(extra_data.to_vec()),
-				bullet_proof,
-			).unwrap();
+				.rewind_bullet_proof(
+					commit,
+					common_nonce.clone(),
+					None,
+					Some(extra_data.to_vec()),
+					bullet_proof,
+				).unwrap();
 		assert_eq!(proof_info.message, message);
-		*/	}
+		*/
+	}
+
+	#[test]
+	fn test_bullet_proof_multisig_rejects_invalid_combinations() {
+		let mut secp = Secp256k1::with_caps(ContextFlag::Commit).unwrap();
+		let value: u64 = 12345678;
+		let common_nonce = SecretKey::new(&secp, &mut SysRng).unwrap();
+		let private_nonce = SecretKey::new(&secp, &mut SysRng).unwrap();
+		let blinding = SecretKey::new(&secp, &mut SysRng).unwrap();
+		let partial_commit = secp.commit(value, blinding.clone()).unwrap();
+		let commit = secp.commit_sum(vec![partial_commit], vec![]).unwrap();
+
+		assert_eq!(
+			secp.bullet_proof_multisig(
+				value,
+				blinding.clone(),
+				common_nonce.clone(),
+				None,
+				None,
+				None,
+				None,
+				None,
+				vec![],
+				None,
+				0,
+			),
+			Err(Error::InvalidParameters),
+		);
+
+		let mut t_one = PublicKey::blank();
+		let mut t_two = PublicKey::blank();
+		assert_eq!(
+			secp.bullet_proof_multisig(
+				value,
+				blinding.clone(),
+				common_nonce.clone(),
+				None,
+				None,
+				None,
+				Some(&mut t_one),
+				Some(&mut t_two),
+				vec![commit],
+				None,
+				1,
+			),
+			Err(Error::InvalidParameters),
+		);
+
+		let mut t_one_sum = PublicKey::blank();
+		let mut t_two_sum = PublicKey::blank();
+		secp.bullet_proof_multisig(
+			value,
+			blinding.clone(),
+			common_nonce.clone(),
+			None,
+			None,
+			None,
+			Some(&mut t_one_sum),
+			Some(&mut t_two_sum),
+			vec![commit],
+			Some(&private_nonce),
+			1,
+		).unwrap();
+
+		assert_eq!(
+			secp.bullet_proof_multisig(
+				value,
+				blinding.clone(),
+				common_nonce.clone(),
+				None,
+				None,
+				None,
+				Some(&mut t_one_sum),
+				Some(&mut t_two_sum),
+				vec![commit],
+				Some(&private_nonce),
+				2,
+			),
+			Err(Error::InvalidParameters),
+		);
+
+		let mut tau_x = SecretKey::new(&secp, &mut SysRng).unwrap();
+		assert_eq!(
+			secp.bullet_proof_multisig(
+				value,
+				blinding,
+				common_nonce,
+				None,
+				None,
+				Some(&mut tau_x),
+				Some(&mut t_one_sum),
+				Some(&mut t_two_sum),
+				vec![commit],
+				Some(&private_nonce),
+				3,
+			),
+			Err(Error::InvalidParameters),
+		);
+	}
 
 	#[test]
 	fn rewind_empty_message() {
-		let secp = Secp256k1::with_caps(ContextFlag::Commit);
-		let blinding = SecretKey::new(&secp, &mut thread_rng());
-		let nonce = SecretKey::new(&secp, &mut thread_rng());
+		let mut secp = Secp256k1::with_caps(ContextFlag::Commit).unwrap();
+		let blinding = SecretKey::new(&secp, &mut SysRng).unwrap();
+		let nonce = SecretKey::new(&secp, &mut SysRng).unwrap();
 		let value = <u64>::max_value() - 1;
 		let commit = secp.commit(value, blinding.clone()).unwrap();
 
-		let mut pm = ProofMessage::from_bytes(&[0u8;32]);
-		let bullet_proof = secp.bullet_proof(value, blinding.clone(), nonce.clone(), nonce.clone(), None, Some(pm.clone()));
-		// Unwind message with same blinding factor
-		let proof_info = secp
-			.rewind_bullet_proof(commit, nonce, None, bullet_proof)
-			.unwrap();
+		let mut pm = ProofMessage::from_bytes(&[0u8;32]).unwrap();
+		let bullet_proof = secp.bullet_proof(value, blinding.clone(), nonce.clone(), nonce.clone(), None, Some(pm.clone())).unwrap();
+			// Unwind message with same blinding factor
+			let proof_info = secp
+				.rewind_bullet_proof(commit, nonce, None, None, bullet_proof)
+				.unwrap();
 		assert_eq!(proof_info.value, value);
-		assert_eq!(blinding, proof_info.blinding);
-		pm.truncate(constants::BULLET_PROOF_MSG_SIZE);
+		assert!(blinding == proof_info.blinding);
+		pm.truncate(constants::BULLET_PROOF_MSG_SIZE).unwrap();
 		assert_eq!(pm, proof_info.message);
 	}
 
 	#[test]
 	fn rewind_message() {
-		let secp = Secp256k1::with_caps(ContextFlag::Commit);
-		let blinding = SecretKey::new(&secp, &mut thread_rng());
-		let nonce = SecretKey::new(&secp, &mut thread_rng());
+		let mut secp = Secp256k1::with_caps(ContextFlag::Commit).unwrap();
+		let blinding = SecretKey::new(&secp, &mut SysRng).unwrap();
+		let nonce = SecretKey::new(&secp, &mut SysRng).unwrap();
 		let value = <u64>::max_value() - 1;
 		let commit = secp.commit(value, blinding.clone()).unwrap();
 
-		let bullet_proof = secp.bullet_proof(value, blinding.clone(), nonce.clone(), nonce.clone(), None, None);
-		// Unwind message with same blinding factor
+		let bullet_proof = secp.bullet_proof(value, blinding.clone(), nonce.clone(), nonce.clone(), None, None).unwrap();
+			// Unwind message with same blinding factor
+			let proof_info = secp
+				.rewind_bullet_proof(commit, nonce.clone(), None, None, bullet_proof)
+				.unwrap();
+		assert_eq!(proof_info.value, value);
+		assert!(blinding == proof_info.blinding);
+
+		// Using a different private nonce requires providing it during rewind.
+		let private_nonce = SecretKey::new(&secp, &mut SysRng).unwrap();
+		let bullet_proof = secp.bullet_proof(value, blinding.clone(), nonce.clone(), private_nonce.clone(), None, None).unwrap();
+		let proof_info = secp.rewind_bullet_proof(commit, nonce.clone(), None, None, bullet_proof).unwrap();
+		assert_eq!(proof_info.value, value);
+		assert_ne!(blinding, proof_info.blinding); // Blinging not recovered because private_nonce is None
 		let proof_info = secp
-			.rewind_bullet_proof(commit, nonce.clone(), None, bullet_proof)
+			.rewind_bullet_proof(commit, nonce, Some(private_nonce), None, bullet_proof)
 			.unwrap();
 		assert_eq!(proof_info.value, value);
 		assert_eq!(blinding, proof_info.blinding);
-
-		// Using a different private nonce should prevent rewind of blinding factor
-		let private_nonce = SecretKey::new(&secp, &mut thread_rng());
-		let bullet_proof = secp.bullet_proof(value, blinding.clone(), nonce.clone(), private_nonce.clone(), None, None);
-		let proof_info = secp
-			.rewind_bullet_proof(commit, nonce, None, bullet_proof)
-			.unwrap();
-		assert_eq!(proof_info.value, value);
-		assert_ne!(blinding, proof_info.blinding);
 	}
 
 	#[ignore]
@@ -1887,8 +2253,8 @@ mod tests {
 	fn bench_bullet_proof_single_vs_multi() {
 		let nano_to_millis = 1.0 / 1_000_000.0;
 
-		let secp = Secp256k1::with_caps(ContextFlag::Commit);
-		let blinding = SecretKey::new(&secp, &mut thread_rng());
+		let mut secp = Secp256k1::with_caps(ContextFlag::Commit).unwrap();
+		let blinding = SecretKey::new(&secp, &mut SysRng).unwrap();
 		let value = 12345678;
 
 		let increments = vec![1, 2, 5, 10, 100, 200];
@@ -1898,7 +2264,7 @@ mod tests {
 			let mut proofs: Vec<RangeProof> = vec![];
 			for i in 0..v {
 				commits.push(secp.commit(value + i as u64, blinding.clone()).unwrap());
-				proofs.push(secp.bullet_proof(value + i as u64, blinding.clone(), blinding.clone(), blinding.clone(), None, None));
+				proofs.push(secp.bullet_proof(value + i as u64, blinding.clone(), blinding.clone(), blinding.clone(), None, None).unwrap());
 			}
 			println!("--------");
 			println!("Comparing {} Proofs", v);
@@ -1927,17 +2293,17 @@ mod tests {
 		let mut commits: Vec<Commitment> = vec![];
 		let mut proofs: Vec<RangeProof> = vec![];
 
-		let secp = Secp256k1::with_caps(ContextFlag::Commit);
-		let blinding = SecretKey::new(&secp, &mut thread_rng());
-		let rewind_nonce  = SecretKey::new(&secp, &mut thread_rng());
-		let private_nonce = SecretKey::new(&secp, &mut thread_rng());
-		let wrong_blinding = SecretKey::new(&secp, &mut thread_rng());
+		let mut secp = Secp256k1::with_caps(ContextFlag::Commit).unwrap();
+		let blinding = SecretKey::new(&secp, &mut SysRng).unwrap();
+		let rewind_nonce  = SecretKey::new(&secp, &mut SysRng).unwrap();
+		let private_nonce = SecretKey::new(&secp, &mut SysRng).unwrap();
+		let wrong_blinding = SecretKey::new(&secp, &mut SysRng).unwrap();
 		let value = 12345678;
 
 		let wrong_commit = secp.commit(value, wrong_blinding).unwrap();
 
 		commits.push(secp.commit(value, blinding.clone()).unwrap());
-		proofs.push(secp.bullet_proof(value, blinding.clone(), rewind_nonce.clone(), private_nonce.clone(), None, None));
+		proofs.push(secp.bullet_proof(value, blinding.clone(), rewind_nonce.clone(), private_nonce.clone(), None, None).unwrap());
 		let proof_range = secp
 			.verify_bullet_proof(commits[0].clone(), proofs[0].clone(), None)
 			.unwrap();
@@ -1963,8 +2329,8 @@ mod tests {
 		proofs = vec![];
 		commits.push(secp.commit(value + 1, blinding.clone()).unwrap());
 		commits.push(secp.commit(value - 1, blinding.clone()).unwrap());
-		proofs.push(secp.bullet_proof(value + 1, blinding.clone(), rewind_nonce.clone(), private_nonce.clone(), None, None));
-		proofs.push(secp.bullet_proof(value - 1, blinding.clone(), rewind_nonce.clone(), private_nonce.clone(), None, None));
+		proofs.push(secp.bullet_proof(value + 1, blinding.clone(), rewind_nonce.clone(), private_nonce.clone(), None, None).unwrap());
+		proofs.push(secp.bullet_proof(value - 1, blinding.clone(), rewind_nonce.clone(), private_nonce.clone(), None, None).unwrap());
 		let proof_range = secp
 			.verify_bullet_proof_multi(commits.clone(), proofs.clone(), None)
 			.unwrap();
@@ -1984,7 +2350,7 @@ mod tests {
 			private_nonce.clone(),
 			Some(extra_data1.clone()),
 			None,
-		));
+		).unwrap());
 		proofs.push(secp.bullet_proof(
 			value - 1,
 			blinding.clone(),
@@ -1992,7 +2358,7 @@ mod tests {
 			private_nonce.clone(),
 			Some(extra_data2.clone()),
 			None,
-		));
+		).unwrap());
 
 		let mut extra_data = vec![];
 		extra_data.push(extra_data1.clone());
@@ -2021,7 +2387,7 @@ mod tests {
 		for i in 1..100 {
 			print!("\r\r\r{}", i);
 			commits.push(secp.commit(value + i as u64, blinding.clone()).unwrap());
-			proofs.push(secp.bullet_proof(value + i as u64, blinding.clone(), rewind_nonce.clone(), private_nonce.clone(), None, None));
+			proofs.push(secp.bullet_proof(value + i as u64, blinding.clone(), rewind_nonce.clone(), private_nonce.clone(), None, None).unwrap());
 			let proof_range = secp.verify_bullet_proof_multi(commits.clone(), proofs.clone(), None); //.unwrap();
 			if proof_range.is_err() {
 				println!(" proofs batch verify failed");


### PR DESCRIPTION
## Address audit comments:

**Cargo.toml**
- enable `bullet-proof-sizing` in the default feature set and remove the obsolete `dev = ["clippy"]` feature.
- dependency cleanup/hardening.

**build.rs**
- change build script `main` to return Result, enabling fallible build steps to propagate explicit errors.
- remove the `-g` compiler flag from the native C build path for release, avoiding debug-symbol generation in release artifacts.
- make compiler discovery fallible, reported through the build script result instead of panicking.
- replace `compile("libsecp256k1.a")` with `try_compile("libsecp256k1.a")?`, so native library compilation failures propagate cleanly.

**fuzz/fuzz_targets/fuzz_aggsig.rs**
- update RNG imports from `Rng`/`thread_rng` to `TryRng` and `SysRng`.
- switch harness randomness to `SysRng` and unwrap `Secp256k1::with_caps(ContextFlag::Full)`, making context creation failure explicit instead of assuming infallible setup.
- update aggregate-signature context creation to the new `AggSigContext::new(&pks).unwrap()` API, removing the old `secp` argument and surfacing construction failures.
- unwrap the new fallible nonce-generation and random-message APIs (`generate_nonce` and `try_fill_bytes`) so setup errors fail fast during fuzz execution.
- change combined-signature verification to use the new `verify(full_sig, msg)` API and assert that verification returns `true`.

**fuzz/fuzz_targets/fuzz_ecdh.rs**
- unwrap `Secp256k1::new` and `SharedSecret::new` so errors become explicit fuzz failures instead of being hidden.

**fuzz/fuzz_targets/fuzz_sign.rs**
- unwrap `Secp256k1::new()` so context initialization failures become explicit fuzz failures instead of being hidden.

**src/aggsig.rs**
- harden `export_secnonce_single` by rejecting verify-only/no-capability contexts, generating the FFI seed with `SysRng`, zeroizing the seed after use, returning a nonce-specific error on FFI failure, constructing the returned `SecretKey` from validated bytes.
- replace the zero-prefix public-key macro with `is_valid_pubkey`, using full public-key validation.
- change `sign_single` to return `AggSigSignature`, require `pubkey_for_e` as a non-optional valid public key, reject incapable contexts, validate optional nonce public keys, use `SysRng` plus seed zeroization.
- change `verify_single` to return `Result`, use `AggSigSignature`, require a valid `pubkey_total_for_e`, reject sign-only/no-capability contexts, validate signatures and public keys before FFI, report malformed verification inputs.
- harden `verify_batch` by returning `Result`, rejecting incapable contexts and oversized batches, validating all public keys and signatures, treating length/input mismatches as failed verification, checking scratch-space allocation.
- update `add_signatures_single` to use `AggSigSignature`, reject incapable contexts, reject empty input, validate the total nonce and all input signatures, validate the combined signature after the FFI call.
- `subtract_partial_signature` for `AggSigSignature`, validate both input signatures before FFI, use zero-initialized signature outputs, validate every returned signature variant, and map unexpected FFI return values to `GenericError`.
- refactor `AggSigContext` ownership and construction by removing `Clone`, storing an owned optional full `Secp256k1` context plus participant public keys, validating participant count and keys, use `SysRng` with seed zeroization, checking for null context creation.
- change `generate_nonce` to return `Result`, validate signer index bounds, fail on a broken aggregate context, propagate failures.
- change `partial_sign` to require mutable context access, validate signer index and context state, use the owned context pointer, mark the aggregate context broken/destroyed on FFI signing failure.
- change `combine_signatures` to require mutable context access, enforce that the partial-signature count matches the participant set, propagate errors.
- change aggregate verification `verify` to use the context's stored participant set instead of caller-provided keys, return `Result`, validate the combined signature, centralize destruction through a null-checking helper used by `Drop`.
- update existing tests to cover the changes.
- add regression coverage for invalid aggregate signatures, including all-zero signatures and non-liftable x-coordinate signatures, and add compact serialization/parsing validation for `AggSigSignature`
- add direct capability tests for `export_secnonce_single`, `sign_single`, and `verify_single`, confirming which context capabilities are accepted or rejected.

**src/ecdh.rs**
- make `SharedSecret::new` return `Result`; validate the input public key before calling FFI, propagate errors.
- for `SharedSecret` replace derived `Clone`, `PartialEq`, `Eq`, and `Debug` with explicit implementations; `Debug` now redacts the secret bytes, equality is constant-time over the shared-secret bytes, and `Clone` reconstructs the wrapper from byte data.
- update all `SharedSecret` index implementations to read through `ffi::SharedSecret::as_bytes()` to keep byte access behind the explicit FFI byte-slice accessor.
- update the ECDH unit test by using `SysRng`, handling new emitted errors.
- update the benchmark by using `SysRng` and unwrap fallibles.

**src/ffi.rs**
- update `NonceFn` to match the hardened C nonce callback contract.
- make `Generator` explicitly `Clone`, remove raw array/debug helper exposure by security reasons, introduce a typed `PedersenCommitment` opaque wrapper with a zeroed FFI constructor.
- restrict `PublicKey` raw storage to crate visibility, disable serde helper generation by security reasons, make the zeroed constructor crate-private.
- disable serde helper generation for raw `Signature` and `RecoverableSignature` wrappers and remove direct raw-data/blank constructors, narrowing public construction paths for opaque signature objects.
- remove array helper and raw debug exposure from `SharedSecret` (security reasons), make `blank` safe, add explicit byte/pointer accessors, zeroize the secret bytes on drop.
- add the typed illegal-callback function binding used by public-key validation.
- align aggregate-signature and batch Schnorr FFI types with the C API.
- replace raw commitment and generator byte pointers across Pedersen commitment parse/serialize/commit/sum/tally/switch APIs with typed `PedersenCommitment`, `Generator`, and `PublicKey` pointers.
- type rangeproof commitment/generator arguments as `PedersenCommitment` and `Generator`, and change min/max outputs in verify to raw mutable pointers, matching the C API's output-parameter style.
- type bulletproof generator creation and proof creation inputs as `Generator`/`PedersenCommitment` pointers, keeping proof generation ABI calls on opaque wrapper types instead of raw byte arrays.
- type bulletproof verify and verify-multi commitment/generator arguments as opaque wrappers and make multi-proof `extra_commit_len` mutable, matching the C API's parameter mutability.
- update bulletproof rewind to the newer C ABI.

**src/key.rs**
- disable the array macro's serde/compact helper generation for `SecretKey` by security reasons, replace row debug with a redacted `Debug` implementation.
- make random secret-key generation fallible, mapping RNG failures to `SysRngFailure`, validating generated bytes through `SecretKey::from_slice` before returning them.
- harden `SecretKey::from_slice` propagating failures, distinguishing all-zero input as `ZeroSecretKey`, and copying bytes only after validity is proven.
- add constant-time `PartialEq`/`Eq` for `SecretKey`, avoiding early-exit equality comparisons on secret bytes.
- add explicit `SecretKey` serde support that serializes raw bytes but validates deserialized data before constructing a key.
- replace public `PublicKey::new` with crate-private `blank()` for internal FFI buffers, and add `pub_j_raw()` to construct the J-generator public key from the raw constant.
- harden `PublicKey::from_combination` by rejecting incapable contexts, empty input, and invalid public keys.
- expand `PublicKey::is_valid` to require a context, reject all-zero keys, add validation by serializing through FFI with illegal-callback detection, verify the serialized length, reparse the result.
- replace infallible FFI public-key conversion with `from_secp256k1_pubkey(secp, pk) -> Result<PublicKey, Error>`, validating the wrapped key before returning it.
- make `PublicKey::from_secret_key` propagate the errors instead of relying on a debug assertion and unconditional success.
- enforce canonical SEC1 encodings in `PublicKey::from_slice`, rejecting invalid sizes, bad compressed/uncompressed prefixes, and hybrid 65-byte public keys before parsing.
- make public-key serialization `serialize_vec` fallible by returning `Result`, rejecting zero keys, detecting illegal callbacks, checking FFI return status and output length.
- harden public-key add/multiply by validating `self` before FFI, preserving capability checks, and mapping FFI failures to `GenericError` instead of misreporting them as invalid secret keys.
- update public-key serde paths for propagating serialization errors through serde instead of assuming compressed serialization always succeeds.
- extend public-key parsing tests to reject hybrid SEC1 encodings, add direct `is_valid` coverage for valid, zero, and malformed non-zero FFI public keys.
- update keypair, invalid-secret, context-capability, and tweak tests to use `SysRng`, unwrap api the returns error.
- extend serde negative/positive coverage by rejecting zero secret-key input, accepting a known valid secret key, round-tripping a generated `SecretKey`, and rejecting hybrid public-key encodings.
- migrate serde round-trip, out-of-range RNG, and bad-public-key slice tests to `SysRng`, `TryRng`, `TryCryptoRng`, and fallible context creation.
- update debug and serialization tests for the new RNG traits, avoid relying on raw `SecretKey` debug output by formatting the inner byte array directly, and unwrap the new fallible public-key serialization results.
- update arithmetic, combination, inverse, negate, and hash tests to use fallible context constructors, `SysRng`, fallible key generation, and constant-time equality assertions where secret keys are compared.

**src/lib.rs**
- split the old generic `Signature` wrapper into explicit `EcdsaSignature` and `AggSigSignature` types, and add secp256k1 field-prime/aggsig `R.x` validation helpers that reject zero, out-of-range, and non-liftable x-coordinates.
- introduce a shared signature-wrapper macro for FFI pointer access and indexing, apply it to both signature types, and limit raw `AsRef<[u8]>` exposure to legacy aggsig usage.
- harden ECDSA signature parsing and serialization by adding `is_valid`, validating DER/compact parse outputs as non-zero in-range scalars.
- add the `AggSigSignature` API with blank construction, structural validation, fallible compact parsing/serialization, validated raw aggsig serialization, and validated raw-data construction so malformed or blank aggsig signatures fail closed.
- update `EcdsaSignature` serde support to use fallible context creation, fallible compact serialization/deserialization, and serde error propagation instead of assuming context and signature operations cannot fail.
- add `AggSigPartialSignature::as_ffi()` so callers can copy the FFI representation explicitly.
- harden recoverable signatures `RecoverableSignature` by adding a zeroed constructor and mutable pointer accessor, checking compact parse/serialize/convert FFI return values, returning `Result` from compact serialization and standard conversion, validating converted ECDSA signatures.
- expand `Error` with specific failure variants for zero secret keys, system RNG failure, generic secp errors, rangeproof generation, nonce export, invalid parameters, serialization, allocation, and broken aggsig contexts.
- add optional bulletproof-generator ownership to `Secp256k1`, destroy it in `Drop`, disable `Send`, `Sync`, `Clone`, and equality support.
- make context creation fallible by returning `Result`, checking null context creation, initializing bulletproof state, randomizing sign-capable contexts with `SysRng`, zeroizing the randomization seed, and mapping RNG/randomization failures to explicit errors.
- update keypair and signing APIs to require `TryCryptoRng`, propagate secret/public-key generation failures.
- harden public-key recovery and verification by validating recovered FFI public keys through the public-key wrapper, accepting only `EcdsaSignature` in `verify`, rejecting malformed signatures and public keys, mapping verification status explicitly.
- lines 969-1075: update capability/invalid-input tests for the new fallible constructors, `SysRng` RNG API, fallible public-key serialization, `PublicKey::blank`, fallible recoverable conversion.
- add a regression that zeroed ECDSA signatures are rejected before verification.

**src/macros.rs**
- split `impl_array_newtype!` into default, `no_serde`, and `no_serde_no_comp` entry points, letting security-sensitive or opaque FFI wrappers suppress serde and comparison/hash helpers.
- replace the unsafe `MaybeUninit` plus `copy_nonoverlapping` clone implementation with a direct `$thing(self.0.clone())`.
- move `Hash`, `PartialEq`, `Eq`, `PartialOrd`, and `Ord` generation into an internal `@compare` block so callers can intentionally disable comparison/hash APIs for wrappers where those operations should not be exposed.
- move serde `Deserialize`/`Serialize` generation into an internal `@serde` block, allowing the new `no_serde` forms to avoid serialization support for raw or sensitive wrapper types.
- narrow `map_vec!` input from an arbitrary expression to an identifier, making the macro contract stricter and matching direct vector variable usage.

**src/pedersen.rs**
- make `Commitment::from_vec` fallible and exact-length only, make blank commitment construction safe/internal, validate public keys before converting them to commitments, use typed FFI commitment outputs.
- harden commitment-to-public-key conversion by parsing the serialized commitment.
- make `RangeProof` equality and serde length-aware.
- replace the zero-prefix public-key macro `is_valid_pubkey` with full `PublicKey::is_valid` checks for optional multisig proof public keys.
- change `RangeProof::bytes` and `RangeProof::len` to return `Result`, add `is_valid`, and reject proof lengths above `MAX_PROOF_SIZE`.
- make `ProofMessage::from_bytes`, `truncate`, and `push` enforce `PROOF_MSG_SIZE` and return errors; redact `ProofMessage` debug output.
- guard `RangeProof` debug formatting with `is_valid` so malformed proof lengths print as invalid instead of slicing unchecked.
- switch `verify_from_commit` to `EcdsaSignature`, propagate commitment-to-public-key errors, use typed commitment parse/serialize helpers, check serialization return status, add `validate_commitment` for canonical parse/serialize validation.
- update `commit`, `commit_blind`, and `commit_value` to use typed commitment/generator FFI pointers, return `InvalidCommit` on failure instead of assuming success.
- change `verify_commit_sum` to return `Result` and propagate parse failures, update `commit_sum` to use typed commitment pointer vectors and typed serialization.
- harden blinding helpers by rejecting empty blind sums, checking native return values, validating derived secret keys, zeroizing temporary secret buffers, using typed switch-commitment generators/public key, replacing `thread_rng` nonce generation with fallible `SysRng`.
- make non-bulletproof-sizing `range_proof` fallible, add capability checks, propagate commitment parse failures.
- make non-bulletproof-sizing `verify_range_proof` reject invalid proof lengths and incapable contexts, propagate commitment parse errors.
- make non-bulletproof-sizing `rewind_range_proof` return `Result`, reject invalid proofs and incapable contexts, propagate commitment/message parsing errors.
- make `range_proof_info` return `Result`, add capability/proof-length validation, and map failed FFI info extraction to `InvalidRangeProof`.
- make `bullet_proof` require mutable context access, return `Result`, validate capabilities, use fallible message padding/truncation, use per-context shared generators, check scratch allocation, use typed generators, enforce proof length, and surface generation failure.
- harden `bullet_proof_multisig` by returning `Result`, validating step-specific pointer/nullability contracts, validating public-key inputs, propagating errors, checking final proof length.
- make `verify_bullet_proof` require mutable context access for generator ownership, reject incapable contexts and invalid proof lengths, propagate errors.
- harden `verify_bullet_proof_multi` by rejecting empty or mismatched inputs, enforcing equal valid proof lengths, validating extra-data vector length.
- extend `rewind_bullet_proof` with optional `private_nonce`, add capability and proof validation, update the FFI call to the newer typed generator/commitment ABI, check scratch allocation, build `ProofInfo` through fallible message construction.
- add `shared_generators` as a per-context lazy initializer, storing generators on `Secp256k1` instead of using the removed global `OnceLock` cache.
- update commitment parse/serialize tests for fallible context creation and typed commitments, and add coverage for `validate_commitment` rejecting malformed serialized commitments.
- update commit-sum tests to unwrap the new `Result<bool, Error>` return and keep the positive/negative tally expectations.
- add regression coverage that a blind sum producing a zero scalar returns `ZeroSecretKey` instead of yielding an invalid secret.
- update multiple tests for `SysRng`, fallible key generation, and the new fallible APIs.
- add negative-path multisig coverage for invalid commitment counts, missing private nonce, invalid step-2 public-key state, and invalid step numbers.